### PR TITLE
Playwright tests, bug fixes, and unified CI deploy pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Spotify API credentials
+# Get yours at https://developer.spotify.com/dashboard
+REACT_APP_SPOTIFY_CLIENT_ID=your_spotify_client_id_here
+REACT_APP_REDIRECT_URI=http://localhost:3000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,6 @@ jobs:
 
     env:
       CI: true
-      REACT_APP_SPOTIFY_CLIENT_ID: test-client-id
-      REACT_APP_REDIRECT_URI: http://localhost:3000
 
     steps:
       - name: Checkout repository
@@ -35,28 +33,51 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run Jest unit tests
+        run: CI=true npm test -- --watchAll=false
+
       - name: Build React app
+        env:
+          REACT_APP_SPOTIFY_CLIENT_ID: ${{ secrets.REACT_APP_SPOTIFY_CLIENT_ID || 'test-client-id' }}
+          REACT_APP_REDIRECT_URI: https://solcala.github.io/cc_jammming_music/
         run: npm run build
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests
+        env:
+          REACT_APP_SPOTIFY_CLIENT_ID: test-client-id
+          REACT_APP_REDIRECT_URI: http://localhost:3000
         run: npx playwright test
 
       - name: Embed Playwright report in build output
         if: always()
         run: mkdir -p build/reports && cp -r playwright-report/* build/reports/ || true
 
-      - name: Upload Playwright report on failure
-        if: failure()
+      - name: Upload Playwright report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ github.run_id }}
           path: |
             playwright-report/
             test-results/
           retention-days: 7
+
+      - name: Publish workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Test and deploy summary"
+            echo "- App URL: https://solcala.github.io/cc_jammming_music/"
+            echo "- Playwright report (after successful deploy): https://solcala.github.io/cc_jammming_music/reports/index.html"
+            echo "- Download report artifact from this run's **Artifacts** section"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Confirm deployment
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: echo "Deployed to GitHub Pages at https://solcala.github.io/cc_jammming_music/" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Deploy to GitHub Pages
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Build, Test, and Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      CI: true
+      REACT_APP_SPOTIFY_CLIENT_ID: test-client-id
+      REACT_APP_REDIRECT_URI: http://localhost:3000
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build React app
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Embed Playwright report in build output
+        if: always()
+        run: mkdir -p build/reports && cp -r playwright-report/* build/reports/ || true
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+
+      - name: Deploy to GitHub Pages
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache
 
 # production
 /build

--- a/README.md
+++ b/README.md
@@ -1,88 +1,83 @@
-# Jammming App
+# Jammming
 
+A React web application that lets you search the Spotify catalog, build custom playlists, and save them directly to your Spotify account.
 
+## Features
 
+- Search tracks by title using the Spotify Web API
+- Preview track name, artist, and album
+- Add and remove tracks from a playlist
+- Name your playlist and save it to Spotify
 
+## Prerequisites
 
+- Node.js 18+
+- A [Spotify Developer](https://developer.spotify.com/dashboard) application with a registered redirect URI
 
+## Setup
 
+1. Clone the repository and install dependencies:
 
+```bash
+git clone https://github.com/solcala/cc_jammming_music.git
+cd cc_jammming_music
+npm install
+```
 
+2.Copy the environment template and fill in your Spotify credentials:
 
+```bash
+cp .env.example .env
+```
 
+Edit `.env` with your `REACT_APP_SPOTIFY_CLIENT_ID` and `REACT_APP_REDIRECT_URI`.
 
+3.Start the development server:
 
+```bash
+npm start
+```
 
-
-
-
-# Getting Started with Create React App
-
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Available Scripts
 
-In the project directory, you can run:
+| Script | Description |
+| --- | --- |
+| `npm start` | Start the development server |
+| `npm test` | Run Jest unit tests in watch mode |
+| `npm run build` | Build for production to `build/` |
+| `npm run test:e2e` | Run all Playwright end-to-end tests |
+| `npm run test:api` | Run Playwright API tests only |
+| `npm run test:ui` | Run Playwright UI tests only |
+| `npm run test:e2e:ui` | Open the Playwright test UI |
 
-### `npm start`
+## Testing
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+### Unit Tests (Jest)
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+```bash
+npm test
+```
 
-### `npm test`
+### End-to-End Tests (Playwright)
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Playwright tests mock all Spotify API calls, so no credentials are required.
 
-### `npm run build`
+```bash
+npx playwright install chromium
+npm run test:e2e
+```
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+## Deployment
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+The project deploys to GitHub Pages via a unified CI workflow (`.github/workflows/deploy.yml`) that builds, runs all tests, and deploys only when tests pass on the `main` branch.
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+## Tech Stack
 
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+- React 18 (Create React App)
+- Spotify Web API (Implicit Grant Flow)
+- Jest + React Testing Library (unit tests)
+- Playwright (end-to-end tests)
+- GitHub Actions (CI/CD)
+- GitHub Pages (hosting)

--- a/README.md
+++ b/README.md
@@ -71,11 +71,32 @@ npm run test:e2e
 
 ## Deployment
 
-The project deploys to GitHub Pages via a unified CI workflow (`.github/workflows/deploy.yml`) that builds, runs all tests, and deploys only when tests pass on the `main` branch.
+The project deploys to GitHub Pages via a unified CI workflow ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)) that runs on every `pull_request` and on `push` to `main`.
 
-When deploying to GitHub Pages, set `REACT_APP_REDIRECT_URI` to your published app URL (for example `https://solcala.github.io/cc_jammming_music/`) and register that exact URI in your Spotify Developer Dashboard.
+### CI pipeline
 
-Playwright reports from CI are embedded at `/reports/index.html` on the deployed site when tests run.
+1. Install dependencies (`npm ci`)
+2. Run Jest unit tests
+3. Build the React app for production
+4. Run Playwright end-to-end tests
+5. Embed the Playwright HTML report in `build/reports/`
+6. Upload the Playwright report as a GitHub Actions artifact (every run)
+7. Deploy to GitHub Pages only when all tests pass on a `main` branch push
+
+### Live URLs
+
+| Resource | URL |
+| --- | --- |
+| App | https://solcala.github.io/cc_jammming_music/ |
+| Playwright report (after successful deploy) | https://solcala.github.io/cc_jammming_music/reports/index.html |
+
+On failed runs, the Playwright report is still available from the **Artifacts** section of the GitHub Actions run page.
+
+### Spotify configuration for production
+
+Set `REACT_APP_REDIRECT_URI` to `https://solcala.github.io/cc_jammming_music/` and register that exact URI in your [Spotify Developer Dashboard](https://developer.spotify.com/dashboard).
+
+For live Spotify login on the deployed app, add a GitHub repository secret named `REACT_APP_SPOTIFY_CLIENT_ID` with your Spotify client ID. Without it, the app still renders; only Spotify authentication will not work in production.
 
 ## Spotify authentication note
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ npm run test:e2e
 
 The project deploys to GitHub Pages via a unified CI workflow (`.github/workflows/deploy.yml`) that builds, runs all tests, and deploys only when tests pass on the `main` branch.
 
+When deploying to GitHub Pages, set `REACT_APP_REDIRECT_URI` to your published app URL (for example `https://solcala.github.io/cc_jammming_music/`) and register that exact URI in your Spotify Developer Dashboard.
+
+Playwright reports from CI are embedded at `/reports/index.html` on the deployed site when tests run.
+
+## Spotify authentication note
+
+This app uses Spotify's implicit grant flow, which Spotify has deprecated for new applications. It remains sufficient for this learning project, but a future migration to Authorization Code with PKCE is recommended for production use.
+
 ## Tech Stack
 
 - React 18 (Create React App)

--- a/e2e/api/auth.spec.ts
+++ b/e2e/api/auth.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '../fixtures/test';
+import { MOCK_ACCESS_TOKEN } from '../fixtures/spotify-mocks';
+
+test.describe('Spotify auth', () => {
+  test('sends bearer token on search requests after hash bootstrap', async ({ page }) => {
+    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
+
+    await page.getByTestId('search-by-input').fill('test song');
+    await page.getByTestId('search-button').click();
+
+    const request = await searchRequest;
+    expect(request.headers().authorization).toBe(`Bearer ${MOCK_ACCESS_TOKEN}`);
+  });
+
+  test('does not redirect to Spotify accounts during mocked tests', async ({ page }) => {
+    let loginRequested = false;
+
+    page.on('request', (request) => {
+      if (request.url().includes('accounts.spotify.com')) {
+        loginRequested = true;
+      }
+    });
+
+    await page.getByTestId('search-by-input').fill('test song');
+    await page.getByTestId('search-button').click();
+
+    await expect(page.getByTestId('track-item-track-1')).toBeVisible();
+    expect(loginRequested).toBe(false);
+  });
+});

--- a/e2e/api/save-playlist.spec.ts
+++ b/e2e/api/save-playlist.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../fixtures/test';
+import { mockPlaylist, mockTracks, mockUser } from '../fixtures/spotify-mocks';
+
+async function searchAndAddFirstTrack(page) {
+  await page.getByTestId('search-by-input').fill('test song');
+  await page.getByTestId('search-button').click();
+  await expect(page.getByTestId('track-item-track-1')).toBeVisible();
+  await page.getByTestId('track-add-track-1').click();
+  await expect(page.getByTestId('track-item-track-1')).toHaveCount(2);
+}
+
+test.describe('Spotify save playlist API', () => {
+  test('calls me, create playlist, and add tracks in order', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+
+    await page.getByTestId('playlist-title-input').fill('My Test Playlist');
+
+    const meRequest = page.waitForRequest('**/api.spotify.com/v1/me');
+    const createPlaylistRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes(`/v1/users/${mockUser.id}/playlists`) &&
+        !request.url().includes('/tracks')
+    );
+    const addTracksRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes(`/playlists/${mockPlaylist.id}/tracks`)
+    );
+
+    // First click populates trackUris state; second click sends the save request.
+    await page.getByTestId('save-playlist-button').click();
+    await page.getByTestId('save-playlist-button').click();
+
+    const me = await meRequest;
+    const createPlaylist = await createPlaylistRequest;
+    const addTracks = await addTracksRequest;
+
+    expect(me.method()).toBe('GET');
+    expect(createPlaylist.postDataJSON()).toEqual({ name: 'My Test Playlist' });
+    expect(addTracks.postDataJSON()).toEqual({
+      uris: [mockTracks[0].uri],
+    });
+
+    expect(me.headers().authorization).toBe(createPlaylist.headers().authorization);
+    expect(createPlaylist.headers().authorization).toBe(addTracks.headers().authorization);
+  });
+
+  test('returns 201 and clears playlist on successful save', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+
+    await page.getByTestId('playlist-title-input').fill('My Test Playlist');
+    await page.getByTestId('save-playlist-button').click();
+    await page.getByTestId('save-playlist-button').click();
+
+    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
+    await expect(page.getByTestId('playlist-title-input')).toHaveValue('');
+    await expect(page.getByTestId('track-remove-track-1')).not.toBeVisible();
+  });
+});

--- a/e2e/api/save-playlist.spec.ts
+++ b/e2e/api/save-playlist.spec.ts
@@ -28,8 +28,6 @@ test.describe('Spotify save playlist API', () => {
         request.url().includes(`/playlists/${mockPlaylist.id}/tracks`)
     );
 
-    // First click populates trackUris state; second click sends the save request.
-    await page.getByTestId('save-playlist-button').click();
     await page.getByTestId('save-playlist-button').click();
 
     const me = await meRequest;
@@ -50,7 +48,6 @@ test.describe('Spotify save playlist API', () => {
     await searchAndAddFirstTrack(page);
 
     await page.getByTestId('playlist-title-input').fill('My Test Playlist');
-    await page.getByTestId('save-playlist-button').click();
     await page.getByTestId('save-playlist-button').click();
 
     await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');

--- a/e2e/api/search.spec.ts
+++ b/e2e/api/search.spec.ts
@@ -33,10 +33,10 @@ test.describe('Spotify search API', () => {
       }
     });
 
-    page.on('dialog', (dialog) => dialog.accept());
     await page.getByTestId('search-button').click();
 
     expect(searchCalled).toBe(false);
+    await expect(page.getByTestId('search-error')).toHaveText('Please enter a song title');
   });
 });
 
@@ -50,5 +50,6 @@ base.describe('Spotify search API errors', () => {
 
     await expect(page.getByTestId('track-item-track-1')).not.toBeVisible();
     await expect(page.getByTestId('track-item-track-2')).not.toBeVisible();
+    await expect(page.getByTestId('search-empty-message')).toHaveText('No results found');
   });
 });

--- a/e2e/api/search.spec.ts
+++ b/e2e/api/search.spec.ts
@@ -1,0 +1,54 @@
+import { test as base, expect } from '@playwright/test';
+import { test } from '../fixtures/test';
+import { bootstrapSpotifyAuth } from '../fixtures/auth';
+import { mockSpotifyApi } from '../fixtures/mock-spotify-api';
+import { mockTracks } from '../fixtures/spotify-mocks';
+
+test.describe('Spotify search API', () => {
+  test('requests search with query and renders mapped tracks', async ({ page }) => {
+    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
+
+    await page.getByTestId('search-by-input').fill('test song');
+    await page.getByTestId('search-button').click();
+
+    const request = await searchRequest;
+    expect(request.method()).toBe('GET');
+    expect(request.url()).toContain('/v1/search');
+    expect(request.url()).toContain('type=track');
+    expect(request.url()).toContain('q=test');
+
+    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+    await expect(page.getByTestId('track-artist-track-1')).toHaveText(
+      mockTracks[0].artists[0].name
+    );
+    await expect(page.getByTestId('track-name-track-2')).toHaveText(mockTracks[1].name);
+  });
+
+  test('does not call search API when query is empty', async ({ page }) => {
+    let searchCalled = false;
+
+    page.on('request', (request) => {
+      if (request.url().includes('/v1/search')) {
+        searchCalled = true;
+      }
+    });
+
+    page.on('dialog', (dialog) => dialog.accept());
+    await page.getByTestId('search-button').click();
+
+    expect(searchCalled).toBe(false);
+  });
+});
+
+base.describe('Spotify search API errors', () => {
+  base('returns no tracks when search responds with 401', async ({ page, baseURL }) => {
+    await mockSpotifyApi(page, { searchStatus: 401 });
+    await bootstrapSpotifyAuth(page, baseURL!);
+
+    await page.getByTestId('search-by-input').fill('test song');
+    await page.getByTestId('search-button').click();
+
+    await expect(page.getByTestId('track-item-track-1')).not.toBeVisible();
+    await expect(page.getByTestId('track-item-track-2')).not.toBeVisible();
+  });
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,14 @@
+import type { Page } from '@playwright/test';
+import { MOCK_ACCESS_TOKEN } from './spotify-mocks';
+
+export async function blockSpotifyLoginRedirect(page: Page) {
+  await page.route('**/accounts.spotify.com/**', (route) =>
+    route.fulfill({ status: 200, body: 'OK' })
+  );
+}
+
+export async function bootstrapSpotifyAuth(page: Page, baseURL: string) {
+  await blockSpotifyLoginRedirect(page);
+  await page.goto(`${baseURL}/#access_token=${MOCK_ACCESS_TOKEN}&expires_in=3600`);
+  await page.waitForLoadState('domcontentloaded');
+}

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -17,7 +17,5 @@ export async function searchAndAddFirstTrack(page: Page) {
 
 export async function savePlaylist(page: Page, name: string) {
   await page.getByTestId('playlist-title-input').fill(name);
-  // First click populates trackUris state; second click sends the save request.
-  await page.getByTestId('save-playlist-button').click();
   await page.getByTestId('save-playlist-button').click();
 }

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -1,0 +1,23 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export async function searchTracks(page: Page, query = 'test song') {
+  await page.getByTestId('search-by-input').fill(query);
+  await page.getByTestId('search-button').click();
+  await expect(page.getByTestId('track-item-track-1')).toBeVisible();
+}
+
+export async function searchAndAddFirstTrack(page: Page) {
+  await searchTracks(page);
+  await page.getByTestId('track-add-track-1').click();
+  await expect(
+    page.getByTestId('playlist-section').getByTestId('track-remove-track-1')
+  ).toBeVisible();
+}
+
+export async function savePlaylist(page: Page, name: string) {
+  await page.getByTestId('playlist-title-input').fill(name);
+  // First click populates trackUris state; second click sends the save request.
+  await page.getByTestId('save-playlist-button').click();
+  await page.getByTestId('save-playlist-button').click();
+}

--- a/e2e/fixtures/mock-spotify-api.ts
+++ b/e2e/fixtures/mock-spotify-api.ts
@@ -1,0 +1,63 @@
+import type { Page, Route } from '@playwright/test';
+import {
+  MOCK_ACCESS_TOKEN,
+  mockPlaylist,
+  mockSearchResponse,
+  mockUser,
+} from './spotify-mocks';
+
+type MockOptions = {
+  searchStatus?: number;
+  meStatus?: number;
+  createPlaylistStatus?: number;
+  addTracksStatus?: number;
+};
+
+export async function mockSpotifyApi(page: Page, options: MockOptions = {}) {
+  const {
+    searchStatus = 200,
+    meStatus = 200,
+    createPlaylistStatus = 201,
+    addTracksStatus = 201,
+  } = options;
+
+  await page.route('**/api.spotify.com/**', async (route: Route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const auth = route.request().headers().authorization;
+
+    if (auth !== `Bearer ${MOCK_ACCESS_TOKEN}`) {
+      return route.fulfill({ status: 401, body: '{}' });
+    }
+
+    if (url.includes('/v1/search') && method === 'GET') {
+      return route.fulfill({
+        status: searchStatus,
+        contentType: 'application/json',
+        body: JSON.stringify(searchStatus === 200 ? mockSearchResponse : {}),
+      });
+    }
+
+    if (url.endsWith('/v1/me') && method === 'GET') {
+      return route.fulfill({
+        status: meStatus,
+        contentType: 'application/json',
+        body: JSON.stringify(meStatus === 200 ? mockUser : {}),
+      });
+    }
+
+    if (url.includes('/playlists') && method === 'POST' && !url.includes('/tracks')) {
+      return route.fulfill({
+        status: createPlaylistStatus,
+        contentType: 'application/json',
+        body: JSON.stringify(createPlaylistStatus === 201 ? mockPlaylist : {}),
+      });
+    }
+
+    if (url.includes('/playlists/') && url.endsWith('/tracks') && method === 'POST') {
+      return route.fulfill({ status: addTracksStatus, body: '' });
+    }
+
+    return route.continue();
+  });
+}

--- a/e2e/fixtures/spotify-mocks.ts
+++ b/e2e/fixtures/spotify-mocks.ts
@@ -1,0 +1,43 @@
+export const MOCK_ACCESS_TOKEN = 'mock-access-token';
+
+export const mockUser = {
+  id: 'test-user-id',
+  display_name: 'Test User',
+};
+
+export const mockTracks = [
+  {
+    id: 'track-1',
+    name: 'Test Song One',
+    uri: 'spotify:track:track-1',
+    artists: [{ name: 'Test Artist' }],
+    album: { name: 'Test Album' },
+  },
+  {
+    id: 'track-2',
+    name: 'Test Song Two',
+    uri: 'spotify:track:track-2',
+    artists: [{ name: 'Another Artist' }],
+    album: { name: 'Another Album' },
+  },
+];
+
+export const mockSearchResponse = {
+  tracks: {
+    items: mockTracks,
+  },
+};
+
+export const mockPlaylist = {
+  id: 'playlist-123',
+  name: 'Test Playlist',
+  uri: 'spotify:playlist:playlist-123',
+};
+
+export const mappedMockTracks = mockTracks.map((track) => ({
+  id: track.id,
+  name: track.name,
+  artist: track.artists[0].name,
+  album: track.album.name,
+  uri: track.uri,
+}));

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -1,0 +1,17 @@
+import { test as base } from '@playwright/test';
+import { bootstrapSpotifyAuth } from './auth';
+import { mockSpotifyApi } from './mock-spotify-api';
+
+export const test = base.extend({
+  page: async ({ page, baseURL }, use) => {
+    await mockSpotifyApi(page);
+
+    if (baseURL) {
+      await bootstrapSpotifyAuth(page, baseURL);
+    }
+
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/ui/remove-track.spec.ts
+++ b/e2e/ui/remove-track.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '../fixtures/test';
+import { mockTracks } from '../fixtures/spotify-mocks';
+import { searchAndAddFirstTrack } from '../fixtures/helpers';
+
+test.describe('Remove track from playlist', () => {
+  test('removes a track from the playlist panel', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+
+    const playlist = page.getByTestId('playlist-section');
+    await expect(playlist.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+
+    await playlist.getByTestId('track-remove-track-1').click();
+
+    await expect(playlist.getByTestId('track-remove-track-1')).not.toBeVisible();
+    await expect(page.getByTestId('track-add-track-1')).toBeVisible();
+    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+  });
+});

--- a/e2e/ui/save-playlist.spec.ts
+++ b/e2e/ui/save-playlist.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '../fixtures/test';
+import { mockTracks } from '../fixtures/spotify-mocks';
+import { searchAndAddFirstTrack, savePlaylist } from '../fixtures/helpers';
+
+test.describe('Save playlist', () => {
+  test('saves playlist and shows success message', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+    await savePlaylist(page, 'Weekend Vibes');
+
+    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
+  });
+
+  test('clears playlist after successful save', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+    await savePlaylist(page, 'Weekend Vibes');
+
+    await expect(page.getByTestId('playlist-title-input')).toHaveValue('');
+    await expect(
+      page.getByTestId('playlist-section').getByTestId('track-remove-track-1')
+    ).not.toBeVisible();
+    await expect(page.getByTestId('track-add-track-1')).toBeVisible();
+    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+  });
+});

--- a/e2e/ui/search-and-add.spec.ts
+++ b/e2e/ui/search-and-add.spec.ts
@@ -23,4 +23,19 @@ test.describe('Search and add to playlist', () => {
     await expect(playlist.getByTestId('track-remove-track-1')).toBeVisible();
     await expect(page.getByTestId('track-add-track-1')).toBeVisible();
   });
+
+  test('shows empty state when search returns no tracks', async ({ page }) => {
+    await page.route('**/api.spotify.com/v1/search*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tracks: { items: [] } }),
+      });
+    });
+
+    await page.getByTestId('search-by-input').fill('missing song');
+    await page.getByTestId('search-button').click();
+
+    await expect(page.getByTestId('search-empty-message')).toHaveText('No results found');
+  });
 });

--- a/e2e/ui/search-and-add.spec.ts
+++ b/e2e/ui/search-and-add.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '../fixtures/test';
+import { mockTracks } from '../fixtures/spotify-mocks';
+import { searchTracks } from '../fixtures/helpers';
+
+test.describe('Search and add to playlist', () => {
+  test('searches for tracks and displays results', async ({ page }) => {
+    await searchTracks(page);
+
+    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+    await expect(page.getByTestId('track-artist-track-1')).toHaveText(
+      mockTracks[0].artists[0].name
+    );
+    await expect(page.getByRole('heading', { name: 'Results' })).toBeVisible();
+  });
+
+  test('adds a track from results to the playlist panel', async ({ page }) => {
+    await searchTracks(page);
+
+    await page.getByTestId('track-add-track-1').click();
+
+    const playlist = page.getByTestId('playlist-section');
+    await expect(playlist.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+    await expect(playlist.getByTestId('track-remove-track-1')).toBeVisible();
+    await expect(page.getByTestId('track-add-track-1')).toBeVisible();
+  });
+});

--- a/e2e/ui/validation.spec.ts
+++ b/e2e/ui/validation.spec.ts
@@ -2,46 +2,28 @@ import { test, expect } from '../fixtures/test';
 import { searchAndAddFirstTrack } from '../fixtures/helpers';
 
 test.describe('Form validation', () => {
-  test('shows alert when searching with an empty query', async ({ page }) => {
-    page.once('dialog', async (dialog) => {
-      expect(dialog.message()).toBe('Please enter a song title');
-      await dialog.accept();
-    });
-
+  test('shows inline error when searching with an empty query', async ({ page }) => {
     await page.getByTestId('search-button').click();
+    await expect(page.getByTestId('search-error')).toHaveText('Please enter a song title');
   });
 
-  test('shows alert when saving without a playlist title', async ({ page }) => {
+  test('shows inline error when saving without a playlist title', async ({ page }) => {
     await searchAndAddFirstTrack(page);
-
-    page.once('dialog', async (dialog) => {
-      expect(dialog.message()).toBe('Add a playlist title');
-      await dialog.accept();
-    });
-
     await page.getByTestId('save-playlist-button').click();
+    await expect(page.getByTestId('playlist-validation-error')).toHaveText('Add a playlist title');
   });
 
-  test('shows alert when saving without tracks', async ({ page }) => {
-    page.once('dialog', async (dialog) => {
-      expect(dialog.message()).toBe('Add at least a track to the playlist');
-      await dialog.accept();
-    });
-
+  test('shows inline error when saving without tracks', async ({ page }) => {
     await page.getByTestId('playlist-title-input').fill('Empty Playlist');
     await page.getByTestId('save-playlist-button').click();
+    await expect(page.getByTestId('playlist-validation-error')).toHaveText('Add at least a track to the playlist');
   });
 
-  test('shows alert when adding a duplicate track', async ({ page }) => {
+  test('shows duplicate track message in playlist panel', async ({ page }) => {
     await searchAndAddFirstTrack(page);
-
-    page.once('dialog', async (dialog) => {
-      expect(dialog.message()).toBe('This song is in the playlist.');
-      await dialog.accept();
-    });
-
     await page.getByTestId('track-add-track-1').click();
 
+    await expect(page.getByTestId('playlist-message')).toHaveText('This song is in the playlist.');
     await expect(
       page.getByTestId('playlist-section').getByTestId('track-remove-track-1')
     ).toHaveCount(1);

--- a/e2e/ui/validation.spec.ts
+++ b/e2e/ui/validation.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '../fixtures/test';
+import { searchAndAddFirstTrack } from '../fixtures/helpers';
+
+test.describe('Form validation', () => {
+  test('shows alert when searching with an empty query', async ({ page }) => {
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toBe('Please enter a song title');
+      await dialog.accept();
+    });
+
+    await page.getByTestId('search-button').click();
+  });
+
+  test('shows alert when saving without a playlist title', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toBe('Add a playlist title');
+      await dialog.accept();
+    });
+
+    await page.getByTestId('save-playlist-button').click();
+  });
+
+  test('shows alert when saving without tracks', async ({ page }) => {
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toBe('Add at least a track to the playlist');
+      await dialog.accept();
+    });
+
+    await page.getByTestId('playlist-title-input').fill('Empty Playlist');
+    await page.getByTestId('save-playlist-button').click();
+  });
+
+  test('shows alert when adding a duplicate track', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toBe('This song is in the playlist.');
+      await dialog.accept();
+    });
+
+    await page.getByTestId('track-add-track-1').click();
+
+    await expect(
+      page.getByTestId('playlist-section').getByTestId('track-remove-track-1')
+    ).toHaveCount(1);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "eslint": "^8.57.1",
         "eslint-plugin-testing-library": "^6.5.0",
         "patch-package": "^8.0.0"
@@ -4147,6 +4148,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -14640,6 +14657,53 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.3.1",
-        "express-session": "^1.18.0",
         "gh-pages": "^6.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -9175,25 +9174,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-session": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
-      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.7",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-headers": "~1.0.2",
-        "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.1",
-        "uid-safe": "~2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16246,15 +16226,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -18913,18 +18884,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "license": "MIT",
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.1",
-    "express-session": "^1.18.0",
     "gh-pages": "^6.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -51,7 +50,10 @@
     ],
     "overrides": [
       {
-        "files": ["e2e/**/*.ts", "e2e/**/*.tsx"],
+        "files": [
+          "e2e/**/*.ts",
+          "e2e/**/*.tsx"
+        ],
         "rules": {
           "testing-library/prefer-screen-queries": "off"
         }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "test": "react-scripts test",
+    "test:e2e": "playwright test",
+    "test:api": "playwright test e2e/api",
+    "test:ui": "playwright test e2e/ui",
+    "test:e2e:ui": "playwright test --ui",
     "eject": "react-scripts eject",
     "postinstall": "patch-package"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc_jammming_music",
-  "homepage":"https://jazcala.github.io/cc_jammming_music/",
+  "homepage": "https://jazcala.github.io/cc_jammming_music/",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -59,6 +59,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "eslint": "^8.57.1",
     "eslint-plugin-testing-library": "^6.5.0",
     "patch-package": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc_jammming_music",
-  "homepage": "https://jazcala.github.io/cc_jammming_music/",
+  "homepage": "https://solcala.github.io/cc_jammming_music/",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,14 @@
     "extends": [
       "react-app",
       "react-app/jest"
+    ],
+    "overrides": [
+      {
+        "files": ["e2e/**/*.ts", "e2e/**/*.tsx"],
+        "rules": {
+          "testing-library/prefer-screen-queries": "off"
+        }
+      }
     ]
   },
   "browserslist": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.PORT || '3000';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'api',
+      testMatch: /api\/.*\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'ui',
+      testMatch: /ui\/.*\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm start',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+    env: {
+      BROWSER: 'none',
+      PORT,
+      REACT_APP_SPOTIFY_CLIENT_ID: process.env.REACT_APP_SPOTIFY_CLIENT_ID || 'test-client-id',
+      REACT_APP_REDIRECT_URI: process.env.REACT_APP_REDIRECT_URI || baseURL,
+    },
+  },
+});

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,6 @@ function App() {
   const [playlistName, setPlaylistName] = useState('');
   const [playlistTracks, setPlaylistTracks] = useState([]);
   const [message, setMessage] = useState("");
-  const [trackUris, setTracksUri] = useState([]);
 
   // Spotify Calls
   const search = useCallback(() => {
@@ -24,19 +23,17 @@ function App() {
   }, [searchBy]);
 
   const savePlaylist = useCallback(async () => {
-
     try {
-      setTracksUri(Array.from(playlistTracks, song => song.uri));
-      const response = await Spotify.savePlaylist(playlistName, trackUris);
+      const uris = playlistTracks.map((song) => song.uri);
+      const response = await Spotify.savePlaylist(playlistName, uris);
       if (response === 201) {
-        clearPlaylist()
-        addMessage()
+        clearPlaylist();
+        addMessage();
       }
-
     } catch (e) {
-      console.log('savePlaylist Error catched: ', e)
+      console.log('savePlaylist Error catched: ', e);
     }
-  }, [playlistName, trackUris, playlistTracks]);
+  }, [playlistName, playlistTracks]);
 
   // Other functions
   const clearPlaylist = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import './App.css';
 import Header from './components/Header';
 import SearchBar from './components/SearchBar';
-import SeachResults from './components/SearchResults';
+import SearchResults from './components/SearchResults';
 import Playlist from './components/Playlist';
 import Spotify from "./util/Spotify";
 
@@ -68,7 +68,7 @@ function App() {
         setSearchBy={setSearchBy}
       />
       <div className='container'>
-        <SeachResults
+        <SearchResults
           className="search-results"
           results={searchResults}
           addToPlaylist={addToPlaylist} />

--- a/src/App.js
+++ b/src/App.js
@@ -12,26 +12,38 @@ function App() {
 
   const [searchBy, setSearchBy] = useState("");
   const [searchResults, setSearchResults] = useState([]);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [playlistName, setPlaylistName] = useState('');
   const [playlistTracks, setPlaylistTracks] = useState([]);
   const [message, setMessage] = useState("");
 
   // Spotify Calls
   const search = useCallback(() => {
+    setIsSearching(true);
+    setHasSearched(true);
     Spotify.search(searchBy)
-      .then(setSearchResults);
+      .then((results) => setSearchResults(results || []))
+      .finally(() => setIsSearching(false));
   }, [searchBy]);
 
   const savePlaylist = useCallback(async () => {
+    setIsSaving(true);
     try {
       const uris = playlistTracks.map((song) => song.uri);
       const response = await Spotify.savePlaylist(playlistName, uris);
       if (response === 201) {
         clearPlaylist();
         addMessage();
+      } else {
+        addMessage('Unable to save playlist. Please try again.');
       }
     } catch (e) {
       console.log('savePlaylist Error catched: ', e);
+      addMessage('Unable to save playlist. Please try again.');
+    } finally {
+      setIsSaving(false);
     }
   }, [playlistName, playlistTracks]);
 
@@ -50,7 +62,7 @@ function App() {
     if (!result) {
       setPlaylistTracks((prev) => [...prev, track]);
     } else {
-      alert('This song is in the playlist.')
+      addMessage('This song is in the playlist.');
     }
 
   };
@@ -66,11 +78,13 @@ function App() {
         search={search}
         searchBy={searchBy}
         setSearchBy={setSearchBy}
+        isSearching={isSearching}
       />
       <div className='container'>
         <SearchResults
           className="search-results"
           results={searchResults}
+          hasSearched={hasSearched}
           addToPlaylist={addToPlaylist} />
         <Playlist className="track-list"
           playlistTracks={playlistTracks}
@@ -80,6 +94,7 @@ function App() {
           savePlaylist={savePlaylist}
           addMessage={addMessage}
           message={message}
+          isSaving={isSaving}
         />
       </div>
     </div>

--- a/src/components/Playlist.js
+++ b/src/components/Playlist.js
@@ -25,12 +25,13 @@ function Playlist({ playlistTracks, removeFromPlaylist, savePlaylist, playlistNa
     }
 
     return (
-        <div className={styles.playlist} id="playlist-section">
-            <p id='message'>{message}</p>
+        <div className={styles.playlist} id="playlist-section" data-testid="playlist-section">
+            <p id='message' data-testid="playlist-message">{message}</p>
             <input
                 aria-label="playlist-title"
                 className={styles.playlistName}
                 id="playlist-title"
+                data-testid="playlist-title-input"
                 onChange={handlePlaylistName}
                 value={playlistName}
                 type="text"
@@ -42,6 +43,7 @@ function Playlist({ playlistTracks, removeFromPlaylist, savePlaylist, playlistNa
             <button id="save-spotify-btn"
                 className={styles.Button}
                 type="button"
+                data-testid="save-playlist-button"
                 onClick={handleSubmitSavePlaylist}>Save to Spotify</button>
         </div>
     )

--- a/src/components/Playlist.js
+++ b/src/components/Playlist.js
@@ -1,14 +1,23 @@
-import React from 'react';
-import './Playlist.module.css'
+import React, { useState } from 'react';
 import Tracklist from './Tracklist';
 import styles from './Playlist.module.css';
 
-function Playlist({ playlistTracks, removeFromPlaylist, savePlaylist, playlistName, setPlaylistName, addMessage, message }) {
-
+function Playlist({
+    playlistTracks,
+    removeFromPlaylist,
+    savePlaylist,
+    playlistName,
+    setPlaylistName,
+    addMessage,
+    message,
+    isSaving = false,
+}) {
+    const [validationError, setValidationError] = useState('');
     const addRemoveTrack = false;
     const handlePlaylistName = (e) => {
         e.preventDefault();
         setPlaylistName(e.target.value);
+        setValidationError('');
         // If name changes and there was a msg, this clears it since it's going to create a new playlist - no update implemented yet
         addMessage("");
     };
@@ -16,11 +25,14 @@ function Playlist({ playlistTracks, removeFromPlaylist, savePlaylist, playlistNa
     const handleSubmitSavePlaylist = (e) => {
         e.preventDefault();
         if (playlistName === '') {
-            return alert('Add a playlist title');
+            setValidationError('Add a playlist title');
+            return;
         }
-        if (playlistTracks.length == 0) {
-            return alert('Add at least a track to the playlist');
+        if (playlistTracks.length === 0) {
+            setValidationError('Add at least a track to the playlist');
+            return;
         }
+        setValidationError('');
         savePlaylist();
     }
 
@@ -40,11 +52,19 @@ function Playlist({ playlistTracks, removeFromPlaylist, savePlaylist, playlistNa
                 tracks={playlistTracks}
                 removeFromPlaylist={removeFromPlaylist}
                 addRemoveTrack={addRemoveTrack} />
+            {validationError && (
+                <p className={styles.error} role="alert" data-testid="playlist-validation-error">
+                    {validationError}
+                </p>
+            )}
             <button id="save-spotify-btn"
                 className={styles.Button}
                 type="button"
                 data-testid="save-playlist-button"
-                onClick={handleSubmitSavePlaylist}>Save to Spotify</button>
+                onClick={handleSubmitSavePlaylist}
+                disabled={isSaving}>
+                {isSaving ? 'Saving...' : 'Save to Spotify'}
+            </button>
         </div>
     )
 }

--- a/src/components/Playlist.module.css
+++ b/src/components/Playlist.module.css
@@ -23,6 +23,12 @@
   margin: 0.5rem 0;
 }
 
+.error {
+  color: #b00020;
+  font-size: 0.875rem;
+  margin: 0.25rem 0;
+}
+
 @media only screen and (min-width: 481px) {
   .playlist {
     width: 50%;

--- a/src/components/Playlist.test.js
+++ b/src/components/Playlist.test.js
@@ -3,19 +3,37 @@ import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Playlist from './Playlist';
 
-it("input to add tittle with placeholder", () => {
-  render(<Playlist />);
+const defaultProps = {
+  playlistTracks: [],
+  removeFromPlaylist: () => {},
+  savePlaylist: () => {},
+  playlistName: '',
+  setPlaylistName: () => {},
+  addMessage: () => {},
+  message: '',
+};
+
+it('input to add title with placeholder', () => {
+  render(<Playlist {...defaultProps} />);
   const input = screen.getByRole('textbox');
   expect(input.getAttribute('placeholder')).toBe('Add a playlist title');
-})
-
-
+});
 
 it('save to playlist button is displayed', () => {
-  render(<Playlist />);
+  render(<Playlist {...defaultProps} />);
   const button = screen.getByRole('button');
   expect(button).toHaveTextContent('Save to Spotify');
-})
+});
 
+it('displays tracks when provided', () => {
+  const tracks = [
+    { id: '1', name: 'My Song', artist: 'Artist X', album: 'Album X', uri: 'spotify:track:1' },
+  ];
+  render(<Playlist {...defaultProps} playlistTracks={tracks} />);
+  expect(screen.getByText('My Song')).toBeInTheDocument();
+});
 
-// TODO add test with mock data
+it('displays the playlist message', () => {
+  render(<Playlist {...defaultProps} message="Playlist created" />);
+  expect(screen.getByTestId('playlist-message')).toHaveTextContent('Playlist created');
+});

--- a/src/components/Playlist.test.js
+++ b/src/components/Playlist.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import Playlist from './Playlist';
 
@@ -36,4 +37,27 @@ it('displays tracks when provided', () => {
 it('displays the playlist message', () => {
   render(<Playlist {...defaultProps} message="Playlist created" />);
   expect(screen.getByTestId('playlist-message')).toHaveTextContent('Playlist created');
+});
+
+it('shows inline error when saving without a playlist title', async () => {
+  const user = userEvent.setup();
+  const tracks = [
+    { id: '1', name: 'My Song', artist: 'Artist X', album: 'Album X', uri: 'spotify:track:1' },
+  ];
+  render(<Playlist {...defaultProps} playlistTracks={tracks} />);
+  await user.click(screen.getByTestId('save-playlist-button'));
+  expect(screen.getByTestId('playlist-validation-error')).toHaveTextContent('Add a playlist title');
+});
+
+it('shows inline error when saving without tracks', async () => {
+  const user = userEvent.setup();
+  render(<Playlist {...defaultProps} playlistName="Empty Playlist" />);
+  await user.click(screen.getByTestId('save-playlist-button'));
+  expect(screen.getByTestId('playlist-validation-error')).toHaveTextContent('Add at least a track to the playlist');
+});
+
+it('shows Saving... while a save is in progress', () => {
+  render(<Playlist {...defaultProps} isSaving={true} />);
+  expect(screen.getByTestId('save-playlist-button')).toHaveTextContent('Saving...');
+  expect(screen.getByTestId('save-playlist-button')).toBeDisabled();
 });

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,23 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './SearchBar.module.css';
 
-function SearchBar({ search, searchBy, setSearchBy }) {
+function SearchBar({ search, searchBy, setSearchBy, isSearching = false }) {
+  const [searchError, setSearchError] = useState('');
 
   const onChangeSearchBy = (e) => {
     e.preventDefault();
     setSearchBy(e.target.value);
-  }
+    if (searchError) {
+      setSearchError('');
+    }
+  };
 
   const handleSearchClick = (e) => {
     e.preventDefault();
-    if (searchBy === "") {
-      return alert('Please enter a song title');
+    if (searchBy === '') {
+      setSearchError('Please enter a song title');
+      return;
     }
+    setSearchError('');
     search();
-  }
+  };
 
   return (
-    <div className={styles.searchBar} >
+    <div className={styles.searchBar}>
       <input
         type="text"
         placeholder="Enter a song title"
@@ -25,11 +31,20 @@ function SearchBar({ search, searchBy, setSearchBy }) {
         value={searchBy}
         data-testid="search-by-input"
       />
-      <button className={styles.searchBtn}
-        type='button'
+      {searchError && (
+        <p className={styles.error} role="alert" data-testid="search-error">
+          {searchError}
+        </p>
+      )}
+      <button
+        className={styles.searchBtn}
+        type="button"
         onClick={handleSearchClick}
         data-testid="search-button"
-      >Search</button>
+        disabled={isSearching}
+      >
+        {isSearching ? 'Searching...' : 'Search'}
+      </button>
     </div>
   );
 }

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -21,3 +21,9 @@ button.searchBtn  {
   display: inline-block;
   margin: 0.5rem 0;
 }
+
+.error {
+  color: #b00020;
+  font-size: 0.875rem;
+  margin: 0.25rem 0;
+}

--- a/src/components/SearchBar.test.js
+++ b/src/components/SearchBar.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SearchBar from './SearchBar';
 import App from '../App';
 
@@ -40,4 +41,30 @@ it('calls search callback when button is clicked with a non-empty query', () => 
   const button = screen.getByTestId('search-button');
   button.click();
   expect(mockSearch).toHaveBeenCalledTimes(1);
+});
+
+it('shows inline error when searching with an empty query', async () => {
+  const user = userEvent.setup();
+  render(
+    <SearchBar
+      search={() => {}}
+      searchBy={''}
+      setSearchBy={() => {}}
+    />
+  );
+  await user.click(screen.getByTestId('search-button'));
+  expect(screen.getByTestId('search-error')).toHaveTextContent('Please enter a song title');
+});
+
+it('shows Searching... while a search is in progress', () => {
+  render(
+    <SearchBar
+      search={() => {}}
+      searchBy={'Song'}
+      setSearchBy={() => {}}
+      isSearching={true}
+    />
+  );
+  expect(screen.getByTestId('search-button')).toHaveTextContent('Searching...');
+  expect(screen.getByTestId('search-button')).toBeDisabled();
 });

--- a/src/components/SearchBar.test.js
+++ b/src/components/SearchBar.test.js
@@ -28,6 +28,16 @@ it('have search button enable', () => {
   expect(button).toBeEnabled();
 });
 
-it('should display search results', () => {
-  // TODO with mock data
+it('calls search callback when button is clicked with a non-empty query', () => {
+  const mockSearch = jest.fn();
+  render(
+    <SearchBar
+      search={mockSearch}
+      searchBy={'Song'}
+      setSearchBy={() => {}}
+    />
+  );
+  const button = screen.getByTestId('search-button');
+  button.click();
+  expect(mockSearch).toHaveBeenCalledTimes(1);
 });

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -2,17 +2,24 @@ import React from 'react';
 import styles from './SearchResults.module.css';
 import Tracklist from './Tracklist';
 
-function SearchResults({ results, addToPlaylist }) {
+function SearchResults({ results, addToPlaylist, hasSearched = false }) {
   const addRemoveTrack = true;
+  const showEmptyState = hasSearched && results.length === 0;
+
   return (
     <div className={styles.searchResults}>
       <h2>Results</h2>
-      <Tracklist
-        tracks={results}
-        addRemoveTrack={addRemoveTrack}
-        addToPlaylist={addToPlaylist} />
+      {showEmptyState ? (
+        <p data-testid="search-empty-message">No results found</p>
+      ) : (
+        <Tracklist
+          tracks={results}
+          addRemoveTrack={addRemoveTrack}
+          addToPlaylist={addToPlaylist}
+        />
+      )}
     </div>
-  )
+  );
 }
 
 export default SearchResults;

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './SearchResults.module.css';
 import Tracklist from './Tracklist';
 
-function SeachResults({ results, addToPlaylist }) {
+function SearchResults({ results, addToPlaylist }) {
   const addRemoveTrack = true;
   return (
     <div className={styles.searchResults}>
@@ -15,4 +15,4 @@ function SeachResults({ results, addToPlaylist }) {
   )
 }
 
-export default SeachResults;
+export default SearchResults;

--- a/src/components/SearchResults.test.js
+++ b/src/components/SearchResults.test.js
@@ -1,17 +1,19 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import SeachResults from './SearchResults';
+import SearchResults from './SearchResults';
 
-
-
+const mockTracks = [
+  { id: '1', name: 'Track A', artist: 'Artist A', album: 'Album A', uri: 'spotify:track:1' },
+];
 
 it('search Results section has results as heading', () => {
-  render(<SeachResults />);
+  render(<SearchResults results={[]} addToPlaylist={() => {}} />);
   const heading = screen.getByRole('heading');
   expect(heading).toHaveTextContent('Results');
+});
 
-})
-
-
-// TODO mock search results for test
+it('renders tracks passed as results', () => {
+  render(<SearchResults results={mockTracks} addToPlaylist={() => {}} />);
+  expect(screen.getByText('Track A')).toBeInTheDocument();
+});

--- a/src/components/SearchResults.test.js
+++ b/src/components/SearchResults.test.js
@@ -17,3 +17,8 @@ it('renders tracks passed as results', () => {
   render(<SearchResults results={mockTracks} addToPlaylist={() => {}} />);
   expect(screen.getByText('Track A')).toBeInTheDocument();
 });
+
+it('shows empty state after a search with no results', () => {
+  render(<SearchResults results={[]} hasSearched={true} addToPlaylist={() => {}} />);
+  expect(screen.getByTestId('search-empty-message')).toHaveTextContent('No results found');
+});

--- a/src/components/Track.js
+++ b/src/components/Track.js
@@ -15,12 +15,17 @@ function Track({ track, addRemoveTrack, addToPlaylist, removeFromPlaylist }) {
   }
 
   return (
-    <div className={styles.Track}>
+    <div className={styles.Track} data-testid={`track-item-${track.id || 'unknown'}`}>
       <div>
-        <h3>{track.name}</h3>
-        <p>{track.artist}</p>
+        <h3 data-testid={`track-name-${track.id || 'unknown'}`}>{track.name}</h3>
+        <p data-testid={`track-artist-${track.id || 'unknown'}`}>{track.artist}</p>
       </div>
-      <button onClick={handleClick}>{addRemoveTrack ? '+' : '-'}</button>
+      <button
+        onClick={handleClick}
+        data-testid={addRemoveTrack ? `track-add-${track.id || 'unknown'}` : `track-remove-${track.id || 'unknown'}`}
+      >
+        {addRemoveTrack ? '+' : '-'}
+      </button>
     </div>
   )
 }

--- a/src/components/Tracklist.js
+++ b/src/components/Tracklist.js
@@ -5,17 +5,14 @@ function Tracklist({ tracks, removeFromPlaylist, addRemoveTrack, addToPlaylist }
 
   return (
     <>
-      {
-        tracks ?
-          tracks.map((song) => (
-            <Track key={song.id}
-              addRemoveTrack={addRemoveTrack}
-              track={song}
-              removeFromPlaylist={removeFromPlaylist}
-              addToPlaylist={addToPlaylist}
-            />
-          )) : console.log('no tracks')
-      }
+      {tracks?.map((song) => (
+        <Track key={song.id}
+          addRemoveTrack={addRemoveTrack}
+          track={song}
+          removeFromPlaylist={removeFromPlaylist}
+          addToPlaylist={addToPlaylist}
+        />
+      ))}
     </>
   )
 }

--- a/src/components/Tracklist.test.js
+++ b/src/components/Tracklist.test.js
@@ -1,8 +1,35 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import Tracklist from './Tracklist';
 
-it('', () => {
+const mockTracks = [
+  { id: '1', name: 'Song One', artist: 'Artist A', album: 'Album A', uri: 'spotify:track:1' },
+  { id: '2', name: 'Song Two', artist: 'Artist B', album: 'Album B', uri: 'spotify:track:2' },
+];
 
-})
-//TODO with mock data
+it('renders a track for each item in the tracks array', () => {
+  render(
+    <Tracklist
+      tracks={mockTracks}
+      addRemoveTrack={true}
+      addToPlaylist={() => {}}
+      removeFromPlaylist={() => {}}
+    />
+  );
+  const headings = screen.getAllByRole('heading');
+  expect(headings).toHaveLength(2);
+  expect(headings[0]).toHaveTextContent('Song One');
+  expect(headings[1]).toHaveTextContent('Song Two');
+});
+
+it('renders nothing when tracks is undefined', () => {
+  render(
+    <Tracklist
+      addRemoveTrack={true}
+      addToPlaylist={() => {}}
+      removeFromPlaylist={() => {}}
+    />
+  );
+  expect(screen.queryAllByTestId(/^track-item-/)).toHaveLength(0);
+});

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -3,7 +3,6 @@ const redirectUri = process.env.REACT_APP_REDIRECT_URI; // Have to add this to y
 let accessToken;
 
 const Spotify = {
-
   loadSpotifyLoginPage() {
     const accessUrl = `https://accounts.spotify.com/authorize?client_id=${clientId}&response_type=token&scope=playlist-modify-public&redirect_uri=${redirectUri}`;
     // This loads the accessUrl in the windows / so the user can add its credentials.
@@ -17,80 +16,79 @@ const Spotify = {
     if (accessTokenMatch && expiresInMatch) {
       accessToken = accessTokenMatch[1];
       const expiresIn = Number(expiresInMatch[1]);
-      window.setTimeout(() => accessToken = '', expiresIn * 1000);
-      window.history.pushState('Access Token', null, '/'); // This clears the parameters, allowing us to grab a new access token when it expires.
+      window.setTimeout(() => (accessToken = ""), expiresIn * 1000);
+      window.history.pushState(
+        "Access Token",
+        null,
+        process.env.PUBLIC_URL || "/",
+      );
       return accessToken;
     }
   },
 
   getAccessToken() {
-
     try {
       if (accessToken) {
         return accessToken;
       }
-      const accessTokenMatch = window.location.href.match(/access_token=([^&]*)/);
+      const accessTokenMatch =
+        window.location.href.match(/access_token=([^&]*)/);
       const expiresInMatch = window.location.href.match(/expires_in=([^&]*)/);
 
       if (!(accessTokenMatch && expiresInMatch)) {
-        this.loadSpotifyLoginPage().then(() => {
-          accessToken = this.checkAccessToken()
-        })
-      } else {
-        accessToken = this.checkAccessToken();
+        this.loadSpotifyLoginPage();
+        return;
       }
-      return accessToken
+
+      accessToken = this.checkAccessToken();
+      return accessToken;
     } catch (error) {
       console.log(error);
     }
-
   },
 
   async search(term) {
-
     try {
       if (!term) {
         return;
       }
       const accessToken = await this.getAccessToken();
-      const response = await fetch(`https://api.spotify.com/v1/search?type=track&q=${term}`, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`
-        }
-      });
+      const response = await fetch(
+        `https://api.spotify.com/v1/search?type=track&q=${term}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
 
       if (response.status === 401) {
-        return []
+        return [];
       }
 
       if (response.ok) {
-
         const jsonResponse = await response.json();
 
         if (!jsonResponse.tracks) {
           return [];
         }
 
-        return jsonResponse.tracks.items.map(track => ({
+        return jsonResponse.tracks.items.map((track) => ({
           id: track.id,
           name: track.name,
           artist: track.artists[0].name,
           album: track.album.name,
-          uri: track.uri
-        }))
-
+          uri: track.uri,
+        }));
       }
       throw new Error(`Request failed - search by  ${term}`);
-
     } catch (error) {
       console.log(`Request failed - search by  ${term}`);
       console.log(error);
     }
-
   },
 
   async savePlaylist(name, trackUris) {
-
     try {
       if (!name || !trackUris.length) {
         return;
@@ -99,39 +97,44 @@ const Spotify = {
       const headers = { Authorization: `Bearer ${accessToken}` };
       let userId;
 
-      const response = await fetch('https://api.spotify.com/v1/me', { headers: headers, cache: 'no-cache' });
+      const response = await fetch("https://api.spotify.com/v1/me", {
+        headers: headers,
+        cache: "no-cache",
+      });
 
       if (response.ok) {
         const jsonResponse = await response.json();
         userId = jsonResponse.id;
-        const response2 = await fetch(`https://api.spotify.com/v1/users/${userId}/playlists`, {
-          headers: headers,
-          method: 'POST',
-          body: JSON.stringify({ name: name })
-        });
+        const response2 = await fetch(
+          `https://api.spotify.com/v1/users/${userId}/playlists`,
+          {
+            headers: headers,
+            method: "POST",
+            body: JSON.stringify({ name: name }),
+          },
+        );
 
         if (response2.ok) {
-          const jsonResponse2 = await response2.json()
+          const jsonResponse2 = await response2.json();
           const playlistId = jsonResponse2.id;
-          const response3 = await fetch(`https://api.spotify.com/v1/users/${userId}/playlists/${playlistId}/tracks`, {
-            headers: headers,
-            method: 'POST',
-            body: JSON.stringify({ uris: trackUris })
-          });
+          const response3 = await fetch(
+            `https://api.spotify.com/v1/users/${userId}/playlists/${playlistId}/tracks`,
+            {
+              headers: headers,
+              method: "POST",
+              body: JSON.stringify({ uris: trackUris }),
+            },
+          );
           if (response3.ok) {
             return response3.status;
           }
         }
-
       }
       throw new Error("Request failed!");
-
     } catch (error) {
-      console.log(error)
-
+      console.log(error);
     }
-
-  }
+  },
 };
 
 export default Spotify;


### PR DESCRIPTION
## Summary
- Add Playwright API and UI tests with mocked Spotify API
- Fix savePlaylist stale state, OAuth redirect path, and getAccessToken bugs
- Add unified GitHub Actions workflow: Jest + Playwright tests, report artifacts, conditional GitHub Pages deploy
- Improve UX with inline validation, loading states, and empty search results
- Fix homepage URL to match GitHub Pages (`solcala.github.io`)

## Test plan
- [ ] CI workflow **Build, Test, and Deploy** passes on this PR
- [ ] Playwright report artifact is downloadable from the Actions run
- [ ] After merge to `main`, app is live at https://solcala.github.io/cc_jammming_music/
- [ ] After merge to `main`, Playwright report is at https://solcala.github.io/cc_jammming_music/reports/index.html