### PR TITLE
Docker Playwright CI and expanded test coverage

### DIFF
--- a/.cursor/rules/e2e-tests.mdc
+++ b/.cursor/rules/e2e-tests.mdc
@@ -1,0 +1,29 @@
+---
+description: Playwright e2e test style — keep tests declarative, push setup into fixtures
+globs: e2e/**/*.ts
+alwaysApply: false
+---
+
+# E2E test practices
+
+- Keep tests **declarative**: arrange → act → assert. A test body should read like a user story, not implementation logic.
+- **Avoid `if` / branching inside tests** (route handlers, conditionals, loops). Extract that behavior into shared fixtures or helpers instead.
+- Reuse existing mocks (`mockSpotifyApi`, `helpers`) with options rather than duplicating inline `page.route` handlers.
+- Prefer named helpers for repeated flows (`searchAndAddFirstTrack`, `savePlaylist`) and for scenario setup (`mockSpotifyApi(page, { createPlaylistStatus: 500 })`).
+- Put conditional routing, delays, and auth/bootstrap logic in `e2e/fixtures/`, not in spec files.
+
+```typescript
+// ❌ BAD — branching inside the test
+await page.route('**/api.spotify.com/**', async (route) => {
+  if (route.request().method() === 'POST') {
+    await route.fulfill({ status: 500, body: '{}' });
+    return;
+  }
+  await route.continue();
+});
+
+// ✅ GOOD — declarative setup via fixture
+await mockSpotifyApi(page, { createPlaylistStatus: 500 });
+await page.getByTestId('save-playlist-button').click();
+await expect(page.getByTestId('playlist-message')).toHaveText('Unable to save playlist. Please try again.');
+```

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-test-deploy:
+  build_and_unit:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
 
     env:
       CI: true
@@ -33,8 +33,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run Jest unit tests
-        run: CI=true npm test -- --watchAll=false
+      - name: Run Jest unit tests with coverage
+        run: npm run test:coverage
 
       - name: Build React app
         env:
@@ -42,18 +42,54 @@ jobs:
           REACT_APP_REDIRECT_URI: https://solcala.github.io/cc_jammming_music/
         run: npm run build
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build/
+          retention-days: 7
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 7
+
+  e2e:
+    needs: build_and_unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-jammy
+      options: --ipc=host
+
+    env:
+      CI: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: .
 
       - name: Run Playwright tests
-        env:
-          REACT_APP_SPOTIFY_CLIENT_ID: test-client-id
-          REACT_APP_REDIRECT_URI: http://localhost:3000
-        run: npx playwright test
-
-      - name: Embed Playwright report in build output
-        if: always()
-        run: mkdir -p build/reports && cp -r playwright-report/* build/reports/ || true
+        run: npm run test:e2e:ci
 
       - name: Upload Playwright report
         if: always()
@@ -65,6 +101,39 @@ jobs:
             test-results/
           retention-days: 7
 
+      - name: Publish e2e summary
+        if: always()
+        run: |
+          {
+            echo "## E2E test summary"
+            echo "- Playwright report artifact: **playwright-report-${{ github.run_id }}**"
+            echo "- Live report (after successful deploy): https://solcala.github.io/cc_jammming_music/reports/index.html"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy:
+    needs: [build_and_unit, e2e]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: .
+
+      - name: Download Playwright report
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: .
+
+      - name: Embed Playwright report in build output
+        run: mkdir -p build/reports && cp -r playwright-report/* build/reports/
+
       - name: Publish workflow summary
         if: always()
         run: |
@@ -72,7 +141,8 @@ jobs:
             echo "## Test and deploy summary"
             echo "- App URL: https://solcala.github.io/cc_jammming_music/"
             echo "- Playwright report (after successful deploy): https://solcala.github.io/cc_jammming_music/reports/index.html"
-            echo "- Download report artifact from this run's **Artifacts** section"
+            echo "- Jest coverage artifact: **coverage**"
+            echo "- Playwright report artifact: **playwright-report-${{ github.run_id }}**"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Confirm deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build React app
         env:
-          REACT_APP_SPOTIFY_CLIENT_ID: ${{ secrets.REACT_APP_SPOTIFY_CLIENT_ID || 'test-client-id' }}
+          REACT_APP_SPOTIFY_CLIENT_ID: ${{ fromJSON(toJSON(secrets)).REACT_APP_SPOTIFY_CLIENT_ID || 'test-client-id' }}
           REACT_APP_REDIRECT_URI: https://solcala.github.io/cc_jammming_music/
         run: npm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,31 @@ jobs:
       - name: Run Jest unit tests with coverage
         run: npm run test:coverage
 
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            node -e "
+              const { total } = require('./coverage/coverage-summary.json');
+              const row = (label, key) =>
+                '| ' + label + ' | ' + total[key].pct + '% (' + total[key].covered + '/' + total[key].total + ') |';
+              console.log([
+                '## Jest coverage',
+                '| Metric | Result |',
+                '| --- | --- |',
+                row('Statements', 'statements'),
+                row('Branches', 'branches'),
+                row('Functions', 'functions'),
+                row('Lines', 'lines'),
+                '',
+                'Download the full HTML report from the **coverage** artifact.',
+              ].join('\n'));
+            " >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Jest coverage" >> "$GITHUB_STEP_SUMMARY"
+            echo "Coverage report not generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Build React app
         env:
           REACT_APP_SPOTIFY_CLIENT_ID: ${{ fromJSON(toJSON(secrets)).REACT_APP_SPOTIFY_CLIENT_ID || 'test-client-id' }}
@@ -141,7 +166,7 @@ jobs:
             echo "## Test and deploy summary"
             echo "- App URL: https://solcala.github.io/cc_jammming_music/"
             echo "- Playwright report (after successful deploy): https://solcala.github.io/cc_jammming_music/reports/index.html"
-            echo "- Jest coverage artifact: **coverage**"
+            echo "- Jest coverage: see **build_and_unit** job summary and **coverage** artifact"
             echo "- Playwright report artifact: **playwright-report-${{ github.run_id }}**"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build
-          path: .
+          path: build
 
       - name: Run Playwright tests
         run: npm run test:e2e:ci
@@ -148,7 +148,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build
-          path: .
+          path: build
 
       - name: Download Playwright report
         uses: actions/download-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /test-results/
 /blob-report/
 /playwright/.cache
+/.playwright-serve
 
 # production
 /build

--- a/README.md
+++ b/README.md
@@ -64,10 +64,36 @@ npm test
 
 Playwright tests mock all Spotify API calls, so no credentials are required.
 
+**Local development** (CRA dev server):
+
 ```bash
 npx playwright install chromium
 npm run test:e2e
 ```
+
+**CI / production build** (serves `build/` at the GitHub Pages subpath):
+
+```bash
+npm run build
+npm run test:e2e:ci
+```
+
+**Docker** (official Playwright image, matches `@playwright/test` v1.61.1):
+
+```bash
+npm run build
+docker run --rm --ipc=host -v "$PWD":/app -w /app mcr.microsoft.com/playwright:v1.61.1-jammy npm run test:e2e:ci
+```
+
+See [`docker/playwright.Dockerfile`](docker/playwright.Dockerfile) for the pinned image reference.
+
+### Unit test coverage
+
+```bash
+npm run test:coverage
+```
+
+Report output is written to `coverage/`.
 
 ## Deployment
 
@@ -87,8 +113,8 @@ The project deploys to GitHub Pages via a unified CI workflow ([`.github/workflo
 
 | Resource | URL |
 | --- | --- |
-| App | https://solcala.github.io/cc_jammming_music/ |
-| Playwright report (after successful deploy) | https://solcala.github.io/cc_jammming_music/reports/index.html |
+| App | [https://solcala.github.io/cc_jammming_music/](https://solcala.github.io/cc_jammming_music/) |
+| Playwright report (after successful deploy) | [https://solcala.github.io/cc_jammming_music/reports/index.html](https://solcala.github.io/cc_jammming_music/reports/index.html) |
 
 On failed runs, the Playwright report is still available from the **Artifacts** section of the GitHub Actions run page.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 | `npm start` | Start the development server |
 | `npm test` | Run Jest unit tests in watch mode |
 | `npm run build` | Build for production to `build/` |
-| `npm run test:e2e` | Run all Playwright end-to-end tests |
+| `npm run test:e2e` | Run Playwright E2E tests against the CRA dev server |
+| `npm run test:e2e:ci` | Run Playwright E2E tests against the production `build/` |
+| `npm run test:coverage` | Run Jest unit tests with coverage report |
 | `npm run test:api` | Run Playwright API tests only |
 | `npm run test:ui` | Run Playwright UI tests only |
 | `npm run test:e2e:ui` | Open the Playwright test UI |
@@ -78,14 +80,14 @@ npm run build
 npm run test:e2e:ci
 ```
 
-**Docker** (official Playwright image, matches `@playwright/test` v1.61.1):
+**Docker** (same image as CI — keep in sync with `@playwright/test` in `package.json`):
 
 ```bash
 npm run build
 docker run --rm --ipc=host -v "$PWD":/app -w /app mcr.microsoft.com/playwright:v1.61.1-jammy npm run test:e2e:ci
 ```
 
-See [`docker/playwright.Dockerfile`](docker/playwright.Dockerfile) for the pinned image reference.
+See [`docker/playwright.Dockerfile`](docker/playwright.Dockerfile) for the pinned image reference. When upgrading `@playwright/test`, update both the Docker image tag and the Dockerfile to the matching Playwright release.
 
 ### Unit test coverage
 
@@ -101,13 +103,29 @@ The project deploys to GitHub Pages via a unified CI workflow ([`.github/workflo
 
 ### CI pipeline
 
-1. Install dependencies (`npm ci`)
-2. Run Jest unit tests
-3. Build the React app for production
-4. Run Playwright end-to-end tests
-5. Embed the Playwright HTML report in `build/reports/`
-6. Upload the Playwright report as a GitHub Actions artifact (every run)
-7. Deploy to GitHub Pages only when all tests pass on a `main` branch push
+The workflow ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)) runs three jobs on every `pull_request` and `push` to `main`:
+
+| Job | Runner | Steps |
+| --- | --- | --- |
+| `build_and_unit` | `ubuntu-latest` | `npm ci` → Jest with coverage → production build → upload `build/` and `coverage/` artifacts |
+| `e2e` | Playwright Docker (`v1.61.1-jammy`) | Download `build/` → `npm run test:e2e:ci` → upload Playwright report |
+| `deploy` | `ubuntu-latest` | Embed report in `build/reports/` → deploy to GitHub Pages (only on successful `main` push) |
+
+E2E tests run against the production `build/` (not the CRA dev server), matching the deployed GitHub Pages subpath.
+
+### CI artifacts and reports
+
+Every workflow run publishes downloadable artifacts and a job summary on the Actions run page:
+
+| Artifact | Job | Contents |
+| --- | --- | --- |
+| `coverage` | `build_and_unit` | Jest HTML and LCOV report (`coverage/`) |
+| `playwright-report-<run_id>` | `e2e` | Playwright HTML report and test traces |
+| `build` | `build_and_unit` | Production build passed to E2E and deploy |
+
+- **Jest coverage %** — shown in the `build_and_unit` job summary
+- **Playwright report (live)** — embedded at `/reports/` after a successful `main` deploy (see Live URLs below)
+- **Failed runs** — download the Playwright report from **Artifacts** on the run page; deploy is skipped until all jobs pass
 
 ### Live URLs
 
@@ -116,7 +134,7 @@ The project deploys to GitHub Pages via a unified CI workflow ([`.github/workflo
 | App | [https://solcala.github.io/cc_jammming_music/](https://solcala.github.io/cc_jammming_music/) |
 | Playwright report (after successful deploy) | [https://solcala.github.io/cc_jammming_music/reports/index.html](https://solcala.github.io/cc_jammming_music/reports/index.html) |
 
-On failed runs, the Playwright report is still available from the **Artifacts** section of the GitHub Actions run page.
+Open `coverage/lcov-report/index.html` locally after `npm run test:coverage` for the Jest HTML report.
 
 ### Spotify configuration for production
 

--- a/docker/playwright.Dockerfile
+++ b/docker/playwright.Dockerfile
@@ -1,0 +1,9 @@
+# Official Playwright image — keep version in sync with @playwright/test in package.json
+FROM mcr.microsoft.com/playwright:v1.61.1-jammy
+
+WORKDIR /app
+
+# Dependencies and source are copied/mounted at runtime in CI.
+# Browsers are preinstalled; do not run `npx playwright install --with-deps`.
+
+CMD ["npm", "run", "test:e2e:ci"]

--- a/e2e/ui/loading-states.spec.ts
+++ b/e2e/ui/loading-states.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '../fixtures/test';
+import {
+  MOCK_ACCESS_TOKEN,
+  mockPlaylist,
+  mockSearchResponse,
+  mockUser,
+} from '../fixtures/spotify-mocks';
+import { searchAndAddFirstTrack } from '../fixtures/helpers';
+
+test.describe('Loading states', () => {
+  test('shows Searching... while search is in progress', async ({ page }) => {
+    let releaseSearch!: () => void;
+    const searchBlocked = new Promise<void>((resolve) => {
+      releaseSearch = resolve;
+    });
+
+    await page.route('**/api.spotify.com/v1/search*', async (route) => {
+      await searchBlocked;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockSearchResponse),
+      });
+    });
+
+    await page.getByTestId('search-by-input').fill('test song');
+    await page.getByTestId('search-button').click();
+
+    await expect(page.getByTestId('search-button')).toHaveText('Searching...');
+    await expect(page.getByTestId('search-button')).toBeDisabled();
+
+    releaseSearch();
+    await expect(page.getByTestId('track-item-track-1')).toBeVisible();
+    await expect(page.getByTestId('search-button')).toHaveText('Search');
+    await expect(page.getByTestId('search-button')).toBeEnabled();
+  });
+
+  test('shows Saving... while save is in progress', async ({ page }) => {
+    let releaseSave!: () => void;
+    const saveBlocked = new Promise<void>((resolve) => {
+      releaseSave = resolve;
+    });
+    let blockSaveMe = false;
+
+    await page.route('**/api.spotify.com/**', async (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+      const auth = route.request().headers().authorization;
+
+      if (auth !== `Bearer ${MOCK_ACCESS_TOKEN}`) {
+        return route.fulfill({ status: 401, body: '{}' });
+      }
+
+      if (url.includes('/v1/search') && method === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockSearchResponse),
+        });
+      }
+
+      if (url.endsWith('/v1/me') && method === 'GET') {
+        if (blockSaveMe) {
+          await saveBlocked;
+        }
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockUser),
+        });
+      }
+
+      if (url.includes('/playlists') && method === 'POST' && !url.includes('/tracks')) {
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify(mockPlaylist),
+        });
+      }
+
+      if (url.includes('/playlists/') && url.endsWith('/tracks') && method === 'POST') {
+        return route.fulfill({ status: 201, body: '' });
+      }
+
+      return route.continue();
+    });
+
+    await searchAndAddFirstTrack(page);
+    await page.getByTestId('playlist-title-input').fill('Weekend Vibes');
+
+    blockSaveMe = true;
+    await page.getByTestId('save-playlist-button').click();
+
+    await expect(page.getByTestId('save-playlist-button')).toHaveText('Saving...');
+    await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
+
+    releaseSave();
+    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
+    await expect(page.getByTestId('save-playlist-button')).toHaveText('Save to Spotify');
+    await expect(page.getByTestId('save-playlist-button')).toBeEnabled();
+  });
+});

--- a/e2e/ui/playlist-message.spec.ts
+++ b/e2e/ui/playlist-message.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '../fixtures/test';
+import { searchAndAddFirstTrack, savePlaylist } from '../fixtures/helpers';
+
+test.describe('Playlist message', () => {
+  test('clears success message when playlist title changes', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+    await savePlaylist(page, 'Weekend Vibes');
+
+    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
+
+    await page.getByTestId('playlist-title-input').fill('New Playlist');
+    await expect(page.getByTestId('playlist-message')).toHaveText('');
+  });
+});

--- a/e2e/ui/remove-track.spec.ts
+++ b/e2e/ui/remove-track.spec.ts
@@ -15,4 +15,19 @@ test.describe('Remove track from playlist', () => {
     await expect(page.getByTestId('track-add-track-1')).toBeVisible();
     await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
   });
+
+  test('shows validation when saving after removing the last track', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+    await page.getByTestId('playlist-title-input').fill('Solo Track');
+
+    const playlist = page.getByTestId('playlist-section');
+    await playlist.getByTestId('track-remove-track-1').click();
+
+    await expect(playlist.getByTestId('track-remove-track-1')).not.toBeVisible();
+    await page.getByTestId('save-playlist-button').click();
+
+    await expect(page.getByTestId('playlist-validation-error')).toHaveText(
+      'Add at least a track to the playlist',
+    );
+  });
 });

--- a/e2e/ui/save-playlist.spec.ts
+++ b/e2e/ui/save-playlist.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../fixtures/test';
 import { mockTracks } from '../fixtures/spotify-mocks';
+import { mockSpotifyApi } from '../fixtures/mock-spotify-api';
 import { searchAndAddFirstTrack, savePlaylist } from '../fixtures/helpers';
 
 test.describe('Save playlist', () => {
@@ -20,5 +21,17 @@ test.describe('Save playlist', () => {
     ).not.toBeVisible();
     await expect(page.getByTestId('track-add-track-1')).toBeVisible();
     await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+  });
+
+  test('shows error message when save fails', async ({ page }) => {
+    await searchAndAddFirstTrack(page);
+    await page.getByTestId('playlist-title-input').fill('Failed Playlist');
+    await mockSpotifyApi(page, { createPlaylistStatus: 500 });
+
+    await page.getByTestId('save-playlist-button').click();
+
+    await expect(page.getByTestId('playlist-message')).toHaveText(
+      'Unable to save playlist. Please try again.'
+    );
   });
 });

--- a/e2e/ui/search-and-add.spec.ts
+++ b/e2e/ui/search-and-add.spec.ts
@@ -24,6 +24,18 @@ test.describe('Search and add to playlist', () => {
     await expect(page.getByTestId('track-add-track-1')).toBeVisible();
   });
 
+  test('adds multiple tracks to the playlist panel', async ({ page }) => {
+    await searchTracks(page);
+    await page.getByTestId('track-add-track-1').click();
+    await page.getByTestId('track-add-track-2').click();
+
+    const playlist = page.getByTestId('playlist-section');
+    await expect(playlist.getByTestId('track-remove-track-1')).toBeVisible();
+    await expect(playlist.getByTestId('track-remove-track-2')).toBeVisible();
+    await expect(playlist.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+    await expect(playlist.getByTestId('track-name-track-2')).toHaveText(mockTracks[1].name);
+  });
+
   test('shows empty state when search returns no tracks', async ({ page }) => {
     await page.route('**/api.spotify.com/v1/search*', async (route) => {
       await route.fulfill({

--- a/e2e/ui/validation.spec.ts
+++ b/e2e/ui/validation.spec.ts
@@ -7,6 +7,14 @@ test.describe('Form validation', () => {
     await expect(page.getByTestId('search-error')).toHaveText('Please enter a song title');
   });
 
+  test('clears search error after typing in the input', async ({ page }) => {
+    await page.getByTestId('search-button').click();
+    await expect(page.getByTestId('search-error')).toBeVisible();
+
+    await page.getByTestId('search-by-input').fill('t');
+    await expect(page.getByTestId('search-error')).not.toBeVisible();
+  });
+
   test('shows inline error when saving without a playlist title', async ({ page }) => {
     await searchAndAddFirstTrack(page);
     await page.getByTestId('save-playlist-button').click();

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "@playwright/test": "^1.61.1",
         "eslint": "^8.57.1",
         "eslint-plugin-testing-library": "^6.5.0",
-        "patch-package": "^8.0.0"
+        "patch-package": "^8.0.0",
+        "serve": "^14.2.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5513,6 +5514,13 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/@zeit/schemas": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -5715,6 +5723,16 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5796,6 +5814,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -6490,6 +6529,146 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/boxen": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+      "integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
@@ -6754,6 +6933,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -6854,6 +7049,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -7673,6 +7899,16 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "license": "MIT"
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -11011,6 +11247,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-port-reachable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+      "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -13837,9 +14086,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -14457,6 +14706,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -16271,6 +16527,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -16677,6 +16959,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/regjsgen": {
@@ -17212,6 +17518,101 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/serve": {
+      "version": "14.2.6",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+      "integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.18.0",
+        "arg": "5.0.2",
+        "boxen": "7.0.0",
+        "chalk": "5.0.1",
+        "chalk-template": "0.4.0",
+        "clipboardy": "3.0.0",
+        "compression": "1.8.1",
+        "is-port-reachable": "4.0.0",
+        "serve-handler": "6.1.7",
+        "update-check": "1.5.4"
+      },
+      "bin": {
+        "serve": "build/main.js"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.5",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-handler/node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-handler/node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -17289,6 +17690,43 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/serve/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/serve/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/serve/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -19029,6 +19467,17 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/update-check": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+      "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -19666,6 +20115,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3267,6 +3267,27 @@
         "@types/yargs-parser": "*"
       }
     },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@jest/reporters/node_modules/jest-util": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
@@ -9921,6 +9942,12 @@
       "integrity": "sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==",
       "license": "Unlicense"
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -10866,6 +10893,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -14452,6 +14490,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -14705,6 +14752,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-is-inside": {
@@ -18914,17 +18970,32 @@
       "license": "MIT"
     },
     "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {
@@ -20546,6 +20617,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "deploy": "gh-pages -d build",
     "test": "react-scripts test",
     "test:e2e": "playwright test",
+    "test:e2e:ci": "CI_SERVE_BUILD=true playwright test",
     "test:api": "playwright test e2e/api",
     "test:ui": "playwright test e2e/ui",
     "test:e2e:ui": "playwright test --ui",
+    "test:coverage": "CI=true npm test -- --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "postinstall": "patch-package"
   },
@@ -76,6 +78,7 @@
     "@playwright/test": "^1.61.1",
     "eslint": "^8.57.1",
     "eslint-plugin-testing-library": "^6.5.0",
-    "patch-package": "^8.0.0"
+    "patch-package": "^8.0.0",
+    "serve": "^14.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     "form-data": "^3.0.4",
     "js-yaml": "^3.14.2",
     "glob": "^10.5.0",
+    "test-exclude": "^7.0.1",
+    "@jest/reporters": {
+      "glob": "^7.2.3"
+    },
     "node-forge": "^1.3.2",
     "qs": "^6.14.1",
     "lodash": "^4.17.23"
@@ -73,6 +77,16 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 60,
+        "functions": 65,
+        "lines": 70,
+        "statements": 70
+      }
+    }
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,34 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const PORT = process.env.PORT || '3000';
-const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${PORT}`;
+const SERVE_BUILD = process.env.CI_SERVE_BUILD === 'true';
+const HOMEPAGE_PATH = '/cc_jammming_music';
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL ||
+  (SERVE_BUILD
+    ? `http://localhost:${PORT}${HOMEPAGE_PATH}`
+    : `http://localhost:${PORT}`);
+
+const devWebServer = {
+  command: 'npm start',
+  url: baseURL,
+  reuseExistingServer: !process.env.CI,
+  timeout: 120 * 1000,
+  env: {
+    BROWSER: 'none',
+    PORT,
+    REACT_APP_SPOTIFY_CLIENT_ID:
+      process.env.REACT_APP_SPOTIFY_CLIENT_ID || 'test-client-id',
+    REACT_APP_REDIRECT_URI: process.env.REACT_APP_REDIRECT_URI || baseURL,
+  },
+};
+
+const ciServeWebServer = {
+  command: `node scripts/prepare-playwright-serve.mjs && npx serve .playwright-serve -l ${PORT}`,
+  url: baseURL,
+  reuseExistingServer: !process.env.CI,
+  timeout: 120 * 1000,
+};
 
 export default defineConfig({
   testDir: './e2e',
@@ -26,16 +53,5 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'npm start',
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-    env: {
-      BROWSER: 'none',
-      PORT,
-      REACT_APP_SPOTIFY_CLIENT_ID: process.env.REACT_APP_SPOTIFY_CLIENT_ID || 'test-client-id',
-      REACT_APP_REDIRECT_URI: process.env.REACT_APP_REDIRECT_URI || baseURL,
-    },
-  },
+  webServer: SERVE_BUILD ? ciServeWebServer : devWebServer,
 });

--- a/scripts/prepare-playwright-serve.mjs
+++ b/scripts/prepare-playwright-serve.mjs
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const buildDir = path.join(root, 'build');
+const serveRoot = path.join(root, '.playwright-serve');
+const homepagePath = '/cc_jammming_music';
+const targetDir = path.join(serveRoot, homepagePath.slice(1));
+
+if (!fs.existsSync(buildDir)) {
+  console.error('build/ not found. Run npm run build first.');
+  process.exit(1);
+}
+
+fs.rmSync(serveRoot, { recursive: true, force: true });
+fs.mkdirSync(targetDir, { recursive: true });
+
+for (const entry of fs.readdirSync(buildDir)) {
+  fs.cpSync(path.join(buildDir, entry), path.join(targetDir, entry), { recursive: true });
+}
+
+console.log(`Prepared ${targetDir} for Playwright (base path ${homepagePath})`);

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,22 +1,204 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import App from './App';
+import Spotify from './util/Spotify';
 
+jest.mock('./util/Spotify');
+
+const mockTracks = [
+  {
+    id: 'track-1',
+    name: 'Test Song One',
+    artist: 'Test Artist',
+    album: 'Test Album',
+    uri: 'spotify:track:track-1',
+  },
+  {
+    id: 'track-2',
+    name: 'Test Song Two',
+    artist: 'Another Artist',
+    album: 'Another Album',
+    uri: 'spotify:track:track-2',
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Spotify.search.mockResolvedValue(mockTracks);
+  Spotify.savePlaylist.mockResolvedValue(201);
+});
+
+async function searchForTracks(user, term = 'test') {
+  await user.type(screen.getByTestId('search-by-input'), term);
+  await user.click(screen.getByTestId('search-button'));
+  await waitFor(() => {
+    expect(screen.getByTestId('track-name-track-1')).toBeInTheDocument();
+  });
+}
 
 it('renders Jamming Title', () => {
   render(<App />);
-  const headerText = screen.getByText(/Jamming/i);
-  expect(headerText).toBeInTheDocument();
+  expect(screen.getByText(/Jamming/i)).toBeInTheDocument();
 });
-
 
 it('user is allow to add title', async () => {
   const user = userEvent.setup();
   render(<App />);
-  const input = screen.getByRole('textbox', { name: 'playlist-title' })
-  const title = "Playlist Title";
-  await user.type(input, title);
-  expect(input).toHaveValue(title);
+  const input = screen.getByRole('textbox', { name: 'playlist-title' });
+  await user.type(input, 'Playlist Title');
+  expect(input).toHaveValue('Playlist Title');
+});
 
-})
+it('search populates results from mocked Spotify', async () => {
+  const user = userEvent.setup();
+  render(<App />);
+
+  await searchForTracks(user);
+
+  expect(Spotify.search).toHaveBeenCalledWith('test');
+  expect(screen.getByTestId('track-name-track-1')).toHaveTextContent('Test Song One');
+  expect(screen.getByTestId('track-name-track-2')).toHaveTextContent('Test Song Two');
+});
+
+it('shows inline error on empty search without calling Spotify', async () => {
+  const user = userEvent.setup();
+  render(<App />);
+
+  await user.click(screen.getByTestId('search-button'));
+
+  expect(screen.getByTestId('search-error')).toHaveTextContent(
+    'Please enter a song title',
+  );
+  expect(Spotify.search).not.toHaveBeenCalled();
+});
+
+it('adds a track from search results to the playlist panel', async () => {
+  const user = userEvent.setup();
+  render(<App />);
+
+  await searchForTracks(user);
+  await user.click(screen.getByTestId('track-add-track-1'));
+
+  const playlist = screen.getByTestId('playlist-section');
+  expect(within(playlist).getByTestId('track-remove-track-1')).toBeInTheDocument();
+  expect(within(playlist).getByTestId('track-name-track-1')).toHaveTextContent(
+    'Test Song One',
+  );
+});
+
+it('shows duplicate track message when adding the same track twice', async () => {
+  const user = userEvent.setup();
+  render(<App />);
+
+  await searchForTracks(user);
+  await user.click(screen.getByTestId('track-add-track-1'));
+  await user.click(screen.getByTestId('track-add-track-1'));
+
+  expect(screen.getByTestId('playlist-message')).toHaveTextContent(
+    'This song is in the playlist.',
+  );
+});
+
+it('removes a track from the playlist panel', async () => {
+  const user = userEvent.setup();
+  render(<App />);
+
+  await searchForTracks(user);
+  await user.click(screen.getByTestId('track-add-track-1'));
+  await user.click(screen.getByTestId('track-remove-track-1'));
+
+  expect(screen.queryByTestId('track-remove-track-1')).not.toBeInTheDocument();
+});
+
+it('clears playlist and shows success message after successful save', async () => {
+  const user = userEvent.setup();
+  render(<App />);
+
+  await user.type(screen.getByTestId('playlist-title-input'), 'My Playlist');
+  await searchForTracks(user);
+  await user.click(screen.getByTestId('track-add-track-1'));
+  await user.click(screen.getByTestId('save-playlist-button'));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('playlist-message')).toHaveTextContent(
+      'Playlist created',
+    );
+  });
+  expect(screen.getByTestId('playlist-title-input')).toHaveValue('');
+  expect(screen.queryByTestId('track-remove-track-1')).not.toBeInTheDocument();
+  expect(Spotify.savePlaylist).toHaveBeenCalledWith('My Playlist', [
+    'spotify:track:track-1',
+  ]);
+});
+
+it('shows error message when save fails', async () => {
+  Spotify.savePlaylist.mockResolvedValue(undefined);
+  const user = userEvent.setup();
+  render(<App />);
+
+  await user.type(screen.getByTestId('playlist-title-input'), 'My Playlist');
+  await searchForTracks(user);
+  await user.click(screen.getByTestId('track-add-track-1'));
+  await user.click(screen.getByTestId('save-playlist-button'));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('playlist-message')).toHaveTextContent(
+      'Unable to save playlist. Please try again.',
+    );
+  });
+});
+
+it('shows Searching... while search is in flight', async () => {
+  let resolveSearch;
+  Spotify.search.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolveSearch = resolve;
+      }),
+  );
+
+  const user = userEvent.setup();
+  render(<App />);
+
+  await user.type(screen.getByTestId('search-by-input'), 'test');
+  await user.click(screen.getByTestId('search-button'));
+
+  expect(screen.getByTestId('search-button')).toHaveTextContent('Searching...');
+  expect(screen.getByTestId('search-button')).toBeDisabled();
+
+  resolveSearch(mockTracks);
+  await waitFor(() => {
+    expect(screen.getByTestId('search-button')).toHaveTextContent('Search');
+  });
+});
+
+it('shows Saving... while save is in flight', async () => {
+  let resolveSave;
+  Spotify.savePlaylist.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        resolveSave = resolve;
+      }),
+  );
+
+  const user = userEvent.setup();
+  render(<App />);
+
+  await user.type(screen.getByTestId('playlist-title-input'), 'My Playlist');
+  await searchForTracks(user);
+  await user.click(screen.getByTestId('track-add-track-1'));
+  await user.click(screen.getByTestId('save-playlist-button'));
+
+  expect(screen.getByTestId('save-playlist-button')).toHaveTextContent(
+    'Saving...',
+  );
+  expect(screen.getByTestId('save-playlist-button')).toBeDisabled();
+
+  resolveSave(201);
+  await waitFor(() => {
+    expect(screen.getByTestId('save-playlist-button')).toHaveTextContent(
+      'Save to Spotify',
+    );
+  });
+});

--- a/src/components/Playlist.test.js
+++ b/src/components/Playlist.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -60,4 +60,31 @@ it('shows Saving... while a save is in progress', () => {
   render(<Playlist {...defaultProps} isSaving={true} />);
   expect(screen.getByTestId('save-playlist-button')).toHaveTextContent('Saving...');
   expect(screen.getByTestId('save-playlist-button')).toBeDisabled();
+});
+
+it('clears validation error when playlist title changes', async () => {
+  const user = userEvent.setup();
+  const tracks = [
+    { id: '1', name: 'My Song', artist: 'Artist X', album: 'Album X', uri: 'spotify:track:1' },
+  ];
+
+  function PlaylistWrapper() {
+    const [playlistName, setPlaylistName] = useState('');
+    return (
+      <Playlist
+        {...defaultProps}
+        playlistTracks={tracks}
+        playlistName={playlistName}
+        setPlaylistName={setPlaylistName}
+      />
+    );
+  }
+
+  render(<PlaylistWrapper />);
+
+  await user.click(screen.getByTestId('save-playlist-button'));
+  expect(screen.getByTestId('playlist-validation-error')).toBeInTheDocument();
+
+  await user.type(screen.getByTestId('playlist-title-input'), 'My Playlist');
+  expect(screen.queryByTestId('playlist-validation-error')).not.toBeInTheDocument();
 });

--- a/src/components/SearchBar.test.js
+++ b/src/components/SearchBar.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SearchBar from './SearchBar';
@@ -67,4 +67,23 @@ it('shows Searching... while a search is in progress', () => {
   );
   expect(screen.getByTestId('search-button')).toHaveTextContent('Searching...');
   expect(screen.getByTestId('search-button')).toBeDisabled();
+});
+
+it('clears search error when user types in the input', async () => {
+  const user = userEvent.setup();
+
+  function SearchBarWrapper() {
+    const [searchBy, setSearchBy] = useState('');
+    return (
+      <SearchBar search={() => {}} searchBy={searchBy} setSearchBy={setSearchBy} />
+    );
+  }
+
+  render(<SearchBarWrapper />);
+
+  await user.click(screen.getByTestId('search-button'));
+  expect(screen.getByTestId('search-error')).toBeInTheDocument();
+
+  await user.type(screen.getByTestId('search-by-input'), 'a');
+  expect(screen.queryByTestId('search-error')).not.toBeInTheDocument();
 });

--- a/src/components/Track.test.js
+++ b/src/components/Track.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import Track from './Track';
 
-const testingTrack = { name: 'Flowers', artist: 'Miley Cyrus' };
+const testingTrack = { id: 'track-1', name: 'Flowers', artist: 'Miley Cyrus' };
 
 it('Track is displayed with add button', () => {
   render(<Track
@@ -37,7 +38,7 @@ it('should displayed track name', () => {
   expect(heading).toHaveTextContent(testingTrack.name)
 })
 
-it('should displayed track name', () => {
+it('should displayed track artist', () => {
   render(<Track track={testingTrack}
     addRemoveTrack={false}
     addToPlaylist={() => { }}
@@ -46,3 +47,37 @@ it('should displayed track name', () => {
   let textArtist = screen.getByRole('paragraph');
   expect(textArtist).toHaveTextContent(testingTrack.artist)
 })
+
+it('calls addToPlaylist when + is clicked', async () => {
+  const addToPlaylist = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Track
+      track={testingTrack}
+      addRemoveTrack={true}
+      addToPlaylist={addToPlaylist}
+      removeFromPlaylist={() => {}}
+    />,
+  );
+
+  await user.click(screen.getByTestId('track-add-track-1'));
+  expect(addToPlaylist).toHaveBeenCalledWith(testingTrack);
+});
+
+it('calls removeFromPlaylist when - is clicked', async () => {
+  const removeFromPlaylist = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Track
+      track={testingTrack}
+      addRemoveTrack={false}
+      addToPlaylist={() => {}}
+      removeFromPlaylist={removeFromPlaylist}
+    />,
+  );
+
+  await user.click(screen.getByTestId('track-remove-track-1'));
+  expect(removeFromPlaylist).toHaveBeenCalledWith(testingTrack);
+});

--- a/src/util/Spotify.test.js
+++ b/src/util/Spotify.test.js
@@ -1,0 +1,163 @@
+let Spotify;
+
+const seedAccessToken = () => {
+  window.location.href =
+    'http://localhost/#access_token=mock-access-token&expires_in=3600';
+  Spotify.checkAccessToken();
+};
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+
+  global.fetch = jest.fn();
+
+  delete window.location;
+  window.location = { href: 'http://localhost/' };
+
+  window.history.pushState = jest.fn();
+
+  process.env.PUBLIC_URL = '/cc_jammming_music';
+
+  Spotify = require('./Spotify').default;
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('checkAccessToken', () => {
+  it('parses hash token and clears URL with PUBLIC_URL', () => {
+    window.location.href =
+      'http://localhost/#access_token=abc123&expires_in=3600';
+
+    const token = Spotify.checkAccessToken();
+
+    expect(token).toBe('abc123');
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      'Access Token',
+      null,
+      '/cc_jammming_music',
+    );
+  });
+});
+
+describe('getAccessToken', () => {
+  it('returns cached token without re-parsing the URL', () => {
+    seedAccessToken();
+    window.location.href = 'http://localhost/';
+
+    expect(Spotify.getAccessToken()).toBe('mock-access-token');
+    expect(Spotify.getAccessToken()).toBe('mock-access-token');
+  });
+});
+
+describe('search', () => {
+  it('returns early on empty term', async () => {
+    const result = await Spotify.search('');
+
+    expect(result).toBeUndefined();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('maps API response to track objects', async () => {
+    seedAccessToken();
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        tracks: {
+          items: [
+            {
+              id: 'track-1',
+              name: 'Test Song',
+              uri: 'spotify:track:track-1',
+              artists: [{ name: 'Test Artist' }],
+              album: { name: 'Test Album' },
+            },
+          ],
+        },
+      }),
+    });
+
+    const tracks = await Spotify.search('test');
+
+    expect(tracks).toEqual([
+      {
+        id: 'track-1',
+        name: 'Test Song',
+        artist: 'Test Artist',
+        album: 'Test Album',
+        uri: 'spotify:track:track-1',
+      },
+    ]);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.spotify.com/v1/search?type=track&q=test',
+      {
+        headers: { Authorization: 'Bearer mock-access-token' },
+      },
+    );
+  });
+
+  it('returns [] on 401', async () => {
+    seedAccessToken();
+    fetch.mockResolvedValueOnce({ ok: false, status: 401 });
+
+    const tracks = await Spotify.search('test');
+
+    expect(tracks).toEqual([]);
+  });
+});
+
+describe('savePlaylist', () => {
+  it('calls /me, create playlist, then add tracks in order', async () => {
+    seedAccessToken();
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'user-1' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'playlist-1' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+      });
+
+    const status = await Spotify.savePlaylist('My Playlist', [
+      'spotify:track:1',
+      'spotify:track:2',
+    ]);
+
+    expect(status).toBe(201);
+    expect(fetch).toHaveBeenNthCalledWith(1, 'https://api.spotify.com/v1/me', {
+      headers: { Authorization: 'Bearer mock-access-token' },
+      cache: 'no-cache',
+    });
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://api.spotify.com/v1/users/user-1/playlists',
+      {
+        headers: { Authorization: 'Bearer mock-access-token' },
+        method: 'POST',
+        body: JSON.stringify({ name: 'My Playlist' }),
+      },
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      3,
+      'https://api.spotify.com/v1/users/user-1/playlists/playlist-1/tracks',
+      {
+        headers: { Authorization: 'Bearer mock-access-token' },
+        method: 'POST',
+        body: JSON.stringify({
+          uris: ['spotify:track:1', 'spotify:track:2'],
+        }),
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Split CI into `build_and_unit`, Playwright Docker `e2e`, and `deploy` jobs; E2E tests run against the production `build/` via `test:e2e:ci`
- Publish Jest coverage and Playwright report artifacts with job-summary visibility
- Expand unit test coverage (Spotify module, App flows, component interactions) and add Jest coverage thresholds
- Add Playwright UI tests for loading states, save errors, validation clearing, and playlist edge cases

## Test plan
- [ ] CI passes on this PR (`build_and_unit`, `e2e`, deploy skipped on PR)
- [ ] `npm run test:coverage` passes locally with thresholds
- [ ] `npm run test:e2e` and `npm run test:e2e:ci` pass locally
- [ ] Review Playwright and coverage artifacts on the Actions run page