### PR TITLE
Add Slack CI notifications (Phase 0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@
 # Get yours at https://developer.spotify.com/dashboard
 REACT_APP_SPOTIFY_CLIENT_ID=your_spotify_client_id_here
 REACT_APP_REDIRECT_URI=http://localhost:3000
+
+# Slack Incoming Webhook (optional — local dry-run only)
+# CI uses the SLACK_WEBHOOK_URL GitHub repository secret instead.
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,7 +126,26 @@ jobs:
           path: build
 
       - name: Run Playwright tests
+        id: playwright
         run: npm run test:e2e:ci
+
+      - name: Write Playwright CI summary for Slack
+        if: always()
+        run: |
+          node scripts/write-playwright-ci-summary.js
+          mkdir -p ci-summary
+          cp test-results/e2e.json ci-summary/e2e.json
+        env:
+          PLAYWRIGHT_STEP_OUTCOME: ${{ steps.playwright.outcome }}
+
+      - name: Upload e2e summary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-e2e
+          path: ci-summary/e2e.json
+          retention-days: 7
+
 
       - name: Upload Playwright report
         if: always()
@@ -188,7 +207,76 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+
+      - name: Write deploy CI summary for Slack
+        if: always()
+        run: |
+          node scripts/write-deploy-ci-summary.js
+          mkdir -p ci-summary
+          cp test-results/deploy.json ci-summary/deploy.json
+        env:
+          DEPLOYED: ${{ steps.pages.outcome == 'success' && 'true' || 'false' }}
+          JOB_FAILED: ${{ failure() && 'true' || 'false' }}
+
+      - name: Upload deploy summary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-deploy
+          path: ci-summary/deploy.json
+          retention-days: 7
+
+  notify:
+    needs: [build_and_unit, e2e, deploy]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download build_and_unit summary
+        if: needs.build_and_unit.result != 'cancelled'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results-build-and-unit
+          path: ci-reports/build_and_unit
+
+      - name: Download e2e summary
+        if: needs.e2e.result != 'cancelled'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results-e2e
+          path: ci-reports/e2e
+
+      - name: Download deploy summary
+        if: needs.deploy.result != 'cancelled'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: test-results-deploy
+          path: ci-reports/deploy
+
+      - name: Merge CI report
+        env:
+          BUILD_AND_UNIT_RESULT: ${{ needs.build_and_unit.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/merge-ci-report.js
+
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: node scripts/send-slack-report.js --report test-results/ci-report.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,21 +173,25 @@ jobs:
 
     steps:
       - name: Checkout repository
+        id: checkout
         uses: actions/checkout@v4
 
       - name: Download build artifact
+        id: download_build
         uses: actions/download-artifact@v4
         with:
           name: build
           path: build
 
       - name: Download Playwright report
+        id: download_playwright
         uses: actions/download-artifact@v4
         with:
           name: playwright-report-${{ github.run_id }}
           path: .
 
       - name: Embed Playwright report in build output
+        id: embed
         run: mkdir -p build/reports && cp -r playwright-report/* build/reports/
 
       - name: Publish workflow summary
@@ -220,8 +224,12 @@ jobs:
           mkdir -p ci-summary
           cp test-results/deploy.json ci-summary/deploy.json
         env:
-          DEPLOYED: ${{ steps.pages.outcome == 'success' && 'true' || 'false' }}
-          JOB_FAILED: ${{ failure() && 'true' || 'false' }}
+          DEPLOYED: ${{ steps.pages.conclusion == 'success' && 'true' || 'false' }}
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          DOWNLOAD_BUILD_OUTCOME: ${{ steps.download_build.outcome }}
+          DOWNLOAD_PLAYWRIGHT_OUTCOME: ${{ steps.download_playwright.outcome }}
+          EMBED_OUTCOME: ${{ steps.embed.outcome }}
+          PAGES_OUTCOME: ${{ steps.pages.outcome }}
 
       - name: Upload deploy summary artifact
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Run Jest unit tests with coverage
         run: npm run test:coverage
 
+      - name: Write Jest CI summary for Slack
+        if: always()
+        run: node scripts/write-jest-ci-summary.js
+
       - name: Publish coverage summary
         if: always()
         run: |
@@ -80,6 +84,14 @@ jobs:
         with:
           name: coverage
           path: coverage/
+          retention-days: 7
+
+      - name: Upload test results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-build-and-unit
+          path: test-results/
           retention-days: 7
 
   e2e:

--- a/README.md
+++ b/README.md
@@ -103,13 +103,14 @@ The project deploys to GitHub Pages via a unified CI workflow ([`.github/workflo
 
 ### CI pipeline
 
-The workflow ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)) runs three jobs on every `pull_request` and `push` to `main`:
+The workflow ([`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)) runs four jobs on every `pull_request` and `push` to `main`:
 
 | Job | Runner | Steps |
 | --- | --- | --- |
-| `build_and_unit` | `ubuntu-latest` | `npm ci` → Jest with coverage → production build → upload `build/` and `coverage/` artifacts |
-| `e2e` | Playwright Docker (`v1.61.1-jammy`) | Download `build/` → `npm run test:e2e:ci` → upload Playwright report |
-| `deploy` | `ubuntu-latest` | Embed report in `build/reports/` → deploy to GitHub Pages (only on successful `main` push) |
+| `build_and_unit` | `ubuntu-latest` | `npm ci` → Jest with coverage → production build → upload `build/`, `coverage/`, and test summary artifacts |
+| `e2e` | Playwright Docker (`v1.61.1-jammy`) | Download `build/` → `npm run test:e2e:ci` → upload Playwright report and e2e summary |
+| `deploy` | `ubuntu-latest` | Embed report in `build/reports/` → deploy to GitHub Pages (only on successful `main` push) → upload deploy summary |
+| `notify` | `ubuntu-latest` | Merge job summaries → post Slack notification (`if: always()`) |
 
 E2E tests run against the production `build/` (not the CRA dev server), matching the deployed GitHub Pages subpath.
 
@@ -135,6 +136,37 @@ Every workflow run publishes downloadable artifacts and a job summary on the Act
 | Playwright report (after successful deploy) | [https://solcala.github.io/cc_jammming_music/reports/index.html](https://solcala.github.io/cc_jammming_music/reports/index.html) |
 
 Open `coverage/lcov-report/index.html` locally after `npm run test:coverage` for the Jest HTML report.
+
+### Slack CI notifications
+
+After each workflow run, the `notify` job merges results from `build_and_unit`, `e2e`, and `deploy` and posts a summary to Slack (when configured).
+
+#### **What gets posted**
+
+- Green or red header based on overall pass/fail
+- Branch, event type, and total passed / failed / skipped counts
+- Per-job breakdown: Jest unit tests (with line coverage %), Playwright E2E tests, and deploy status
+- Link to the GitHub Actions run
+
+On pull requests, deploy is skipped — the Slack message still reports test results with deploy marked as skipped.
+
+#### **One-time setup**
+
+1. In Slack, create an [Incoming Webhook](https://api.slack.com/messaging/webhooks) for your channel.
+2. In GitHub, go to **Settings → Secrets and variables → Actions** and add a repository secret named `SLACK_WEBHOOK_URL` with the webhook URL.
+
+If the secret is not set, the `notify` job logs a warning and exits successfully — CI is not blocked.
+
+##### **Local dry-run**
+
+Use a sample report to preview the Slack message without running the full pipeline:
+
+```bash
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL \
+  node scripts/send-slack-report.js --report scripts/sample-slack-report.json
+```
+
+A failure example is in [`scripts/sample-slack-report-failure.json`](scripts/sample-slack-report-failure.json). You can also set `SLACK_WEBHOOK_URL` in `.env` for local use (see [`.env.example`](.env.example)); never commit a real webhook URL.
 
 ### Spotify configuration for production
 

--- a/ci-reports/deploy/deploy.json
+++ b/ci-reports/deploy/deploy.json
@@ -1,0 +1,1 @@
+{"status":"success","passed":0,"failed":0,"skipped":0,"durationMs":0,"deployed":false}

--- a/ci-reports/e2e/e2e.json
+++ b/ci-reports/e2e/e2e.json
@@ -1,0 +1,7 @@
+{
+  "status": "success",
+  "passed": 24,
+  "failed": 0,
+  "skipped": 0,
+  "durationMs": 4922.148999999999
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:api": "playwright test e2e/api",
     "test:ui": "playwright test e2e/ui",
     "test:e2e:ui": "playwright test --ui",
-    "test:coverage": "CI=true npm test -- --coverage --watchAll=false",
+    "test:coverage": "mkdir -p test-results && CI=true npm test -- --coverage --watchAll=false --json --outputFile=test-results/jest.json",
     "eject": "react-scripts eject",
     "postinstall": "patch-package"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "deploy": "gh-pages -d build",
     "test": "react-scripts test",
     "test:e2e": "playwright test",
-    "test:e2e:ci": "CI_SERVE_BUILD=true playwright test",
+    "test:e2e:ci": "mkdir -p test-results && CI_SERVE_BUILD=true playwright test",
     "test:api": "playwright test e2e/api",
     "test:ui": "playwright test e2e/ui",
     "test:e2e:ui": "playwright test --ui",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: [['html', { open: 'never' }], ['list']],
+  reporter: [
+    ['html', { open: 'never' }],
+    ['list'],
+    ['json', { outputFile: 'test-results/playwright.json' }],
+  ],
   use: {
     baseURL,
     trace: 'on-first-retry',

--- a/scripts/merge-ci-report.js
+++ b/scripts/merge-ci-report.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const outputPath = path.join(root, 'test-results', 'ci-report.json');
+
+const jobs = ['build_and_unit', 'e2e', 'deploy'];
+
+const summaryPaths = {
+  build_and_unit: [
+    'ci-reports/build_and_unit/build_and_unit.json',
+  ],
+  e2e: ['ci-reports/e2e/e2e.json'],
+  deploy: ['ci-reports/deploy/deploy.json'],
+};
+
+const resultEnv = {
+  build_and_unit: process.env.BUILD_AND_UNIT_RESULT,
+  e2e: process.env.E2E_RESULT,
+  deploy: process.env.DEPLOY_RESULT,
+};
+
+function findSummary(jobName) {
+  for (const relativePath of summaryPaths[jobName]) {
+    const absolutePath = path.join(root, relativePath);
+    if (fs.existsSync(absolutePath)) {
+      return JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+    }
+  }
+  return null;
+}
+
+function fallbackSummary(jobName) {
+  const result = resultEnv[jobName];
+
+  if (result === 'success') {
+    return {
+      status: 'success',
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      durationMs: 0,
+      ...(jobName === 'deploy' ? { deployed: false } : {}),
+    };
+  }
+
+  if (result === 'skipped') {
+    return {
+      status: 'skipped',
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      durationMs: 0,
+      ...(jobName === 'deploy' ? { deployed: false } : {}),
+    };
+  }
+
+  return {
+    status: 'failure',
+    passed: 0,
+    failed: 1,
+    skipped: 0,
+    durationMs: 0,
+    ...(jobName === 'deploy' ? { deployed: false } : {}),
+  };
+}
+
+const report = {
+  workflow: process.env.GITHUB_WORKFLOW || 'CI',
+  ref: process.env.GITHUB_REF_NAME || 'unknown',
+  event: process.env.GITHUB_EVENT_NAME || 'unknown',
+  runUrl: process.env.GITHUB_RUN_URL || '',
+  jobs: {},
+};
+
+for (const jobName of jobs) {
+  report.jobs[jobName] = findSummary(jobName) || fallbackSummary(jobName);
+}
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+console.log(`Wrote ${outputPath}`);

--- a/scripts/sample-slack-report-failure.json
+++ b/scripts/sample-slack-report-failure.json
@@ -1,0 +1,31 @@
+{
+  "workflow": "Build, Test, and Deploy",
+  "ref": "feat/phase-0-slack-reports",
+  "event": "pull_request",
+  "runUrl": "https://github.com/solcala/cc_jammming_music/actions/runs/987654321",
+  "jobs": {
+    "build_and_unit": {
+      "status": "success",
+      "passed": 44,
+      "failed": 0,
+      "skipped": 0,
+      "durationMs": 11000,
+      "coverage": { "lines": 79.5 }
+    },
+    "e2e": {
+      "status": "failure",
+      "passed": 22,
+      "failed": 2,
+      "skipped": 0,
+      "durationMs": 52000
+    },
+    "deploy": {
+      "status": "skipped",
+      "passed": 0,
+      "failed": 0,
+      "skipped": 0,
+      "durationMs": 0,
+      "deployed": false
+    }
+  }
+}

--- a/scripts/sample-slack-report.json
+++ b/scripts/sample-slack-report.json
@@ -1,0 +1,31 @@
+{
+  "workflow": "Build, Test, and Deploy",
+  "ref": "main",
+  "event": "push",
+  "runUrl": "https://github.com/solcala/cc_jammming_music/actions/runs/123456789",
+  "jobs": {
+    "build_and_unit": {
+      "status": "success",
+      "passed": 44,
+      "failed": 0,
+      "skipped": 0,
+      "durationMs": 12000,
+      "coverage": { "lines": 80.26 }
+    },
+    "e2e": {
+      "status": "success",
+      "passed": 24,
+      "failed": 0,
+      "skipped": 0,
+      "durationMs": 45000
+    },
+    "deploy": {
+      "status": "success",
+      "passed": 0,
+      "failed": 0,
+      "skipped": 0,
+      "durationMs": 8000,
+      "deployed": true
+    }
+  }
+}

--- a/scripts/send-slack-report.js
+++ b/scripts/send-slack-report.js
@@ -78,7 +78,7 @@ function aggregateTotals(report) {
       acc.failed += readNumber(job.failed);
       acc.skipped += readNumber(job.skipped);
       acc.durationMs += readNumber(job.durationMs);
-      if (job.status && job.status !== 'success') {
+      if (job.status && job.status !== 'success' && job.status !== 'skipped') {
         acc.failedJobs += 1;
       }
       return acc;

--- a/scripts/send-slack-report.js
+++ b/scripts/send-slack-report.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Send a CI test summary to Slack via Incoming Webhook.
+ *
+ * Usage:
+ *   node scripts/send-slack-report.js --report path/to/report.json
+ *   TEST_PASSED=10 TEST_FAILED=0 node scripts/send-slack-report.js
+ *
+ * Requires: process.env.SLACK_WEBHOOK_URL
+ */
+
+const fs = require('fs');
+const https = require('https');
+const { URL } = require('url');
+
+function parseArgs(argv) {
+  const args = { reportPath: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i] === '--report' && argv[i + 1]) {
+      args.reportPath = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function readNumber(value, fallback = 0) {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function loadReportFromEnv() {
+  const passed = readNumber(process.env.TEST_PASSED);
+  const failed = readNumber(process.env.TEST_FAILED);
+  const skipped = readNumber(process.env.TEST_SKIPPED);
+  const durationMs = readNumber(process.env.TEST_DURATION_MS);
+
+  return {
+    workflow: process.env.WORKFLOW_NAME || 'CI',
+    ref: process.env.GITHUB_REF_NAME || process.env.REF || 'unknown',
+    event: process.env.GITHUB_EVENT_NAME || process.env.EVENT || 'workflow_run',
+    runUrl: process.env.RUN_URL || process.env.GITHUB_RUN_URL || '',
+    jobs: {
+      summary: {
+        status:
+          process.env.WORKFLOW_STATUS ||
+          (failed > 0 ? 'failure' : 'success'),
+        passed,
+        failed,
+        skipped,
+        durationMs,
+        jobName: process.env.JOB_NAME || 'tests',
+      },
+    },
+  };
+}
+
+function loadReport(reportPath) {
+  if (reportPath) {
+    const raw = fs.readFileSync(reportPath, 'utf8');
+    return JSON.parse(raw);
+  }
+  return loadReportFromEnv();
+}
+
+function aggregateTotals(report) {
+  const jobs = Object.values(report.jobs || {});
+  if (jobs.length === 0) {
+    return { passed: 0, failed: 0, skipped: 0, durationMs: 0, failedJobs: 0 };
+  }
+
+  return jobs.reduce(
+    (acc, job) => {
+      acc.passed += readNumber(job.passed);
+      acc.failed += readNumber(job.failed);
+      acc.skipped += readNumber(job.skipped);
+      acc.durationMs += readNumber(job.durationMs);
+      if (job.status && job.status !== 'success') {
+        acc.failedJobs += 1;
+      }
+      return acc;
+    },
+    { passed: 0, failed: 0, skipped: 0, durationMs: 0, failedJobs: 0 },
+  );
+}
+
+function formatDuration(durationMs) {
+  if (!durationMs) {
+    return 'n/a';
+  }
+  const seconds = Math.round(durationMs / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return `${minutes}m ${remainder}s`;
+}
+
+function buildBlocks(report) {
+  const totals = aggregateTotals(report);
+  const allGreen = totals.failed === 0 && totals.failedJobs === 0;
+  const headerEmoji = allGreen ? ':large_green_circle:' : ':red_circle:';
+  const headerText = allGreen ? 'CI Passed' : 'CI Failed';
+
+  const blocks = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: `${headerEmoji} ${headerText} — ${report.workflow || 'CI'}`,
+        emoji: true,
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        { type: 'mrkdwn', text: `*Branch*\n\`${report.ref || 'unknown'}\`` },
+        { type: 'mrkdwn', text: `*Event*\n\`${report.event || 'unknown'}\`` },
+        { type: 'mrkdwn', text: `*Passed*\n${totals.passed}` },
+        { type: 'mrkdwn', text: `*Failed*\n${totals.failed}` },
+        { type: 'mrkdwn', text: `*Skipped*\n${totals.skipped}` },
+        { type: 'mrkdwn', text: `*Duration*\n${formatDuration(totals.durationMs)}` },
+      ],
+    },
+  ];
+
+  const jobLines = Object.entries(report.jobs || {}).map(([name, job]) => {
+    const icon = job.status === 'success' ? ':white_check_mark:' : ':x:';
+    const coverage =
+      job.coverage && job.coverage.lines !== undefined
+        ? ` | coverage ${job.coverage.lines}%`
+        : '';
+    const deployed = job.deployed === true ? ' | deployed' : '';
+    return `${icon} *${name}* — ${readNumber(job.passed)} passed, ${readNumber(job.failed)} failed (${formatDuration(job.durationMs)})${coverage}${deployed}`;
+  });
+
+  if (jobLines.length > 0) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: jobLines.join('\n') },
+    });
+  }
+
+  if (report.runUrl) {
+    blocks.push({
+      type: 'section',
+      text: { type: 'mrkdwn', text: `<${report.runUrl}|View workflow run>` },
+    });
+  }
+
+  blocks.push({
+    type: 'context',
+    elements: [{ type: 'mrkdwn', text: 'Jammming CI report' }],
+  });
+
+  return blocks;
+}
+
+function postToSlack(webhookUrl, payload) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(webhookUrl);
+    const body = JSON.stringify(payload);
+
+    const req = https.request(
+      {
+        hostname: url.hostname,
+        path: `${url.pathname}${url.search}`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let responseBody = '';
+        res.on('data', (chunk) => {
+          responseBody += chunk;
+        });
+        res.on('end', () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(responseBody);
+            return;
+          }
+          reject(
+            new Error(
+              `Slack webhook failed (${res.statusCode}): ${responseBody || 'no body'}`,
+            ),
+          );
+        });
+      },
+    );
+
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+async function main() {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    console.warn('SLACK_WEBHOOK_URL is not set; skipping Slack notification.');
+    process.exit(0);
+  }
+
+  const { reportPath } = parseArgs(process.argv);
+  const report = loadReport(reportPath);
+  const blocks = buildBlocks(report);
+  const fallbackText = aggregateTotals(report).failed > 0 ? 'CI Failed' : 'CI Passed';
+
+  await postToSlack(webhookUrl, { text: fallbackText, blocks });
+  console.log('Slack notification sent.');
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/write-deploy-ci-summary.js
+++ b/scripts/write-deploy-ci-summary.js
@@ -6,7 +6,16 @@ const outputPath = path.join(root, 'test-results', 'deploy.json');
 const appUrl = 'https://solcala.github.io/cc_jammming_music/';
 
 const deployed = process.env.DEPLOYED === 'true';
-const jobFailed = process.env.JOB_FAILED === 'true';
+const stepOutcomes = [
+  process.env.CHECKOUT_OUTCOME,
+  process.env.DOWNLOAD_BUILD_OUTCOME,
+  process.env.DOWNLOAD_PLAYWRIGHT_OUTCOME,
+  process.env.EMBED_OUTCOME,
+  process.env.PAGES_OUTCOME,
+].filter(Boolean);
+const jobFailed = stepOutcomes.some(
+  (outcome) => outcome !== 'success' && outcome !== 'skipped'
+);
 
 const summary = {
   status: jobFailed ? 'failure' : 'success',

--- a/scripts/write-deploy-ci-summary.js
+++ b/scripts/write-deploy-ci-summary.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const outputPath = path.join(root, 'test-results', 'deploy.json');
+const appUrl = 'https://solcala.github.io/cc_jammming_music/';
+
+const deployed = process.env.DEPLOYED === 'true';
+const jobFailed = process.env.JOB_FAILED === 'true';
+
+const summary = {
+  status: jobFailed ? 'failure' : 'success',
+  passed: 0,
+  failed: jobFailed ? 1 : 0,
+  skipped: 0,
+  durationMs: 0,
+  deployed,
+  ...(deployed ? { appUrl } : {}),
+};
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`);
+console.log(`Wrote ${outputPath}`);

--- a/scripts/write-jest-ci-summary.js
+++ b/scripts/write-jest-ci-summary.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const jestPath = path.join(root, 'test-results', 'jest.json');
+const coveragePath = path.join(root, 'coverage', 'coverage-summary.json');
+const outputPath = path.join(root, 'test-results', 'build_and_unit.json');
+
+if (!fs.existsSync(jestPath)) {
+  console.error('test-results/jest.json not found. Run npm run test:coverage first.');
+  process.exit(1);
+}
+
+const jestReport = JSON.parse(fs.readFileSync(jestPath, 'utf8'));
+
+const durationMs = Array.isArray(jestReport.testResults)
+  ? jestReport.testResults.reduce((total, suite) => {
+      if (
+        typeof suite.startTime === 'number' &&
+        typeof suite.endTime === 'number'
+      ) {
+        return total + (suite.endTime - suite.startTime);
+      }
+      return total;
+    }, 0)
+  : 0;
+
+let coverage;
+if (fs.existsSync(coveragePath)) {
+  const { total } = JSON.parse(fs.readFileSync(coveragePath, 'utf8'));
+  coverage = { lines: total.lines.pct };
+}
+
+const summary = {
+  status: jestReport.success ? 'success' : 'failure',
+  passed: jestReport.numPassedTests ?? 0,
+  failed: jestReport.numFailedTests ?? 0,
+  skipped: jestReport.numPendingTests ?? 0,
+  durationMs,
+  ...(coverage ? { coverage } : {}),
+};
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`);
+console.log(`Wrote ${outputPath}`);

--- a/scripts/write-playwright-ci-summary.js
+++ b/scripts/write-playwright-ci-summary.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const playwrightPath = path.join(root, 'test-results', 'playwright.json');
+const outputPath = path.join(root, 'test-results', 'e2e.json');
+
+function summaryFromOutcome(outcome) {
+  return {
+    status: outcome === 'success' ? 'success' : 'failure',
+    passed: 0,
+    failed: outcome === 'success' ? 0 : 1,
+    skipped: 0,
+    durationMs: 0,
+  };
+}
+
+let summary;
+if (fs.existsSync(playwrightPath)) {
+  const report = JSON.parse(fs.readFileSync(playwrightPath, 'utf8'));
+  const stats = report.stats || {};
+  const unexpected = stats.unexpected ?? 0;
+  const flaky = stats.flaky ?? 0;
+
+  summary = {
+    status: unexpected > 0 || flaky > 0 ? 'failure' : 'success',
+    passed: stats.expected ?? 0,
+    failed: unexpected + flaky,
+    skipped: stats.skipped ?? 0,
+    durationMs: stats.duration ?? 0,
+  };
+} else {
+  summary = summaryFromOutcome(process.env.PLAYWRIGHT_STEP_OUTCOME || 'failure');
+}
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`);
+console.log(`Wrote ${outputPath}`);


### PR DESCRIPTION
## Summary
- Add `send-slack-report.js` with Slack blocks payload (green/red status, job breakdown, Actions run link)
- Export Jest and Playwright test summaries from CI as JSON artifacts
- Add `notify` job that merges job results and posts to Slack when `SLACK_WEBHOOK_URL` is configured
- Document webhook setup, repo secret, and local dry-run in README and `.env.example`

## Test plan
- [ ] Confirm CI passes on this PR (build_and_unit, e2e, deploy, notify)
- [ ] Verify `notify` job logs skip warning when `SLACK_WEBHOOK_URL` secret is unset
- [ ] Add `SLACK_WEBHOOK_URL` repo secret and confirm Slack message on pass/fail
- [ ] Local dry-run: `SLACK_WEBHOOK_URL=… node scripts/send-slack-report.js --report scripts/sample-slack-report.json`