### PR TITLE
Feat/qa testing standards

### DIFF
--- a/.cursor/rules/e2e-tests.mdc
+++ b/.cursor/rules/e2e-tests.mdc
@@ -1,16 +1,46 @@
 ---
-description: Playwright e2e test style — keep tests declarative, push setup into fixtures
+description: Playwright e2e style — declarative specs, POM actions, fixtures for setup
 globs: e2e/**/*.ts
 alwaysApply: false
 ---
 
 # E2E test practices
 
-- Keep tests **declarative**: arrange → act → assert. A test body should read like a user story, not implementation logic.
-- **Avoid `if` / branching inside tests** (route handlers, conditionals, loops). Extract that behavior into shared fixtures or helpers instead.
-- Reuse existing mocks (`mockSpotifyApi`, `helpers`) with options rather than duplicating inline `page.route` handlers.
-- Prefer named helpers for repeated flows (`searchAndAddFirstTrack`, `savePlaylist`) and for scenario setup (`mockSpotifyApi(page, { createPlaylistStatus: 500 })`).
-- Put conditional routing, delays, and auth/bootstrap logic in `e2e/fixtures/`, not in spec files.
+Also follow [`.cursor/rules/qa-testing-standards.mdc`](qa-testing-standards.mdc) for contract, POM, and clean-test rules.
+
+## Spec shape
+
+- Keep tests **declarative**: arrange → act → assert. A test body should read like a user story.
+- **Avoid `if` / branching / loops inside tests.** Extract that into `e2e/fixtures/` (or later `e2e/pages/` action helpers).
+- Prefer **atomic** tests that run independently.
+
+## Page Objects (target pattern)
+
+- Put selectors and user actions in `e2e/pages/` (Page Objects).
+- **No `expect` / assertions inside Page Objects.**
+- Specs call page actions, then assert with `expect` in the spec file.
+
+Until page objects exist, keep shared flows in `e2e/fixtures/helpers.ts` but **move assertions out of helpers into specs** when touching those helpers.
+
+## Selectors
+
+- Use **`data-testid`** for interactions and assertions.
+- Reuse existing mocks (`mockSpotifyApi`, auth bootstrap) with options rather than duplicating inline `page.route` handlers.
+
+## Waiting & verification
+
+- **No `waitForTimeout`.** Use `waitForRequest` / `waitForResponse` / `toBeVisible`.
+- After UI actions that call Spotify, **double-verify** network + UI.
+
+## Mocks
+
+- Default happy-path Spotify mocking is allowed for CI.
+- For synthetic edge cases (401, 500, delayed responses), add:
+
+```typescript
+// [QA_AUDIT_REQUIRED]: Mocking 500 on create playlist. Cannot force Spotify server errors in CI.
+await mockSpotifyApi(page, { createPlaylistStatus: 500 });
+```
 
 ```typescript
 // ❌ BAD — branching inside the test
@@ -25,5 +55,7 @@ await page.route('**/api.spotify.com/**', async (route) => {
 // ✅ GOOD — declarative setup via fixture
 await mockSpotifyApi(page, { createPlaylistStatus: 500 });
 await page.getByTestId('save-playlist-button').click();
-await expect(page.getByTestId('playlist-message')).toHaveText('Unable to save playlist. Please try again.');
+await expect(page.getByTestId('playlist-message')).toHaveText(
+  'Unable to save playlist. Please try again.',
+);
 ```

--- a/.cursor/rules/qa-testing-standards.mdc
+++ b/.cursor/rules/qa-testing-standards.mdc
@@ -1,0 +1,84 @@
+---
+description: Quality & Automation Engineering standards for Jammming tests (API contracts, Playwright POM, clean tests)
+globs: "{e2e,src}/**/*.{ts,tsx}"
+alwaysApply: false
+---
+
+# Quality & Automation Engineering Rules
+
+These standards apply when writing or changing unit, API, or Playwright tests.
+
+## Jammming appendix (project-specific)
+
+- This app is a **browser-only SPA** with **no database or first-party backend**.
+- **Reconciliation** means Spotify **API contract + UI state** checks — not SQL.
+- **Default Spotify mocking stays** (`mockSpotifyApi`, `bootstrapSpotifyAuth`) for CI speed and determinism.
+- Add `// [QA_AUDIT_REQUIRED]: ...` only on **synthetic edge mocks** (401, 500, delayed gates) — not on the default happy-path mock.
+- Page Objects live under `e2e/pages/` (introduced in later batches). Until then, keep selectors/actions in fixtures/helpers and **assertions only in `*.spec.ts`**.
+
+## 1. API Testing Standards
+
+### Contract-First
+
+- Use **Zod** schemas for Spotify request/response validation in E2E (and prefer the same shapes for unit fixtures).
+- Canonical mock payloads in `e2e/fixtures/spotify-mocks.ts` must stay aligned with those schemas.
+
+### Data Integrity (Reconciliation)
+
+- After a UI action that triggers Spotify traffic, **double-verify**:
+  1. Outbound request (`waitForRequest` / method / URL / body / auth header)
+  2. UI outcome (`data-testid` visibility / text)
+- Compare API outcomes against **canonical fixtures** (`spotify-mocks.ts`), not a database.
+
+### Error States & Mocks
+
+- Happy-path Spotify routes may remain mocked for CI.
+- For edge cases that cannot be triggered reliably against live Spotify in this environment (forced 500, delayed responses, etc.), mocking is allowed **only with an audit comment**:
+
+```typescript
+// [QA_AUDIT_REQUIRED]: Mocking 500 on create playlist. Cannot force Spotify server errors in CI.
+await mockSpotifyApi(page, { createPlaylistStatus: 500 });
+```
+
+## 2. UI Testing Standards (Playwright)
+
+### POM Pattern (Strict)
+
+- Page Objects are for **selectors and actions only**.
+- **NO ASSERTIONS** inside Page Objects (`e2e/pages/**`).
+- Assertions belong only in `*.spec.ts` files (or assertion helpers imported exclusively by specs — never by page objects).
+
+### Selector Stability
+
+- Prefer **`data-testid` only** for E2E interactions and assertions.
+- Keep ARIA roles on components for real accessibility; do not rely on `getByRole` in E2E once testids cover the same elements.
+
+### Double-Verification
+
+- Always verify state changes after a UI action that hits the network (API request + UI).
+- Client-only actions (e.g. add/remove track in memory) still need a clear UI state assertion.
+
+## 3. General Testing Principles (Clean Test Rule)
+
+- **NO logic in tests:** Do not use `if`, `for`, or complex conditionals inside `*.spec.ts`.
+- If behavior branches, **split into two distinct tests**.
+- Put route handlers, request tracking, and delays in `e2e/fixtures/`.
+- **Atomic tests:** independent, idempotent, runnable in isolation.
+- **No `waitForTimeout`.** Use `waitForRequest` / `waitForResponse` / `expect(...).toBeVisible()` (and related Playwright auto-waiting).
+
+## 4. AI-Native Workflow (Self-Audit)
+
+When generating or changing a test:
+
+1. **Explain the why** — short note of the business flow under test (search → add → save, etc.).
+2. **Audit mocks** — if a non-default mock is used, justify why the live environment cannot trigger it.
+3. **Traceability** — prefer request/response waits and visibility assertions over sleeps.
+
+## Quick checklist
+
+- [ ] Assertions only in specs (not in page objects)
+- [ ] Selectors via `data-testid`
+- [ ] No `if` / loops in specs
+- [ ] No `waitForTimeout`
+- [ ] Network + UI double-check when Spotify is called
+- [ ] `QA_AUDIT_REQUIRED` on synthetic error/delay mocks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,32 @@ Open [http://127.0.0.1:3000/cc_jammming_music/](http://127.0.0.1:3000/cc_jammmin
 ## Coding notes
 
 - Preserve existing `data-testid` and accessibility attributes used by Playwright.
-- E2E specs stay declarative: put branching/helpers in `e2e/fixtures/`, not inside tests.
+- E2E specs stay declarative: put branching/helpers in `e2e/fixtures/` (and later `e2e/pages/`), not inside tests.
 - Do not commit secrets (`.env`, webhook URLs, client secrets). `.env` is gitignored.
+
+## Testing standards
+
+Quality rules for this repo live in:
+
+- [`.cursor/rules/qa-testing-standards.mdc`](.cursor/rules/qa-testing-standards.mdc) — API contracts, Playwright POM, clean tests, mock audit comments
+- [`.cursor/rules/e2e-tests.mdc`](.cursor/rules/e2e-tests.mdc) — Playwright-specific style
+
+**Highlights for contributors:**
+
+- Prefer **`data-testid`** selectors in E2E.
+- **Assertions belong in `*.spec.ts`**, not in Page Objects.
+- **No `if` / loops / `waitForTimeout` in specs** — use fixtures and Playwright auto-waiting (`waitForRequest`, `toBeVisible`).
+- After UI actions that call Spotify, **double-verify** the network request and the UI outcome.
+- Default Spotify mocks are fine for CI. For synthetic 401/500/delay scenarios, add `// [QA_AUDIT_REQUIRED]: ...` with a short justification.
+- There is **no app database**; “reconciliation” means Spotify API contract + UI state (Zod schemas land in a later batch).
+
+Before opening a PR that touches tests or app behavior, run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test:all
+```
 
 ## Dependabot
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,45 @@ Open [http://127.0.0.1:3000/cc_jammming_music/](http://127.0.0.1:3000/cc_jammmin
 
 ## Testing
 
+Quality standards for this repo are documented in:
+
+- [`.cursor/rules/qa-testing-standards.mdc`](.cursor/rules/qa-testing-standards.mdc) — API contracts, Playwright POM, clean tests, mock audit comments
+- [`.cursor/rules/e2e-tests.mdc`](.cursor/rules/e2e-tests.mdc) — Playwright-specific style
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contributor testing checklist
+
+`npm run lint` also runs `scripts/qa-test-guards.mjs`, which fails if `waitForTimeout` appears under `e2e/` or `expect(` appears under `e2e/pages/`.
+
+### Layout (E2E)
+
+```text
+e2e/
+  pages/           # Page objects (selectors + actions only — no assertions)
+  schemas/         # Zod Spotify request/response contracts
+  fixtures/        # Mocks, auth bootstrap, request-tracking helpers
+  api/             # API reconciliation specs
+  ui/              # Desktop UI specs
+  ui/mobile/       # Mobile smoke specs
+```
+
+```mermaid
+flowchart LR
+  Specs["*.spec.ts"] --> POM["e2e/pages/"]
+  Specs --> Zod["e2e/schemas/"]
+  Specs --> Fixtures["e2e/fixtures/"]
+  POM --> UI["UI actions"]
+  Zod --> Contracts["Request / response parse"]
+  Fixtures --> Mocks["mockSpotifyApi + auth"]
+```
+
+### Contract-first + reconciliation
+
+This app is a browser-only SPA with **no database**. “Reconciliation” means:
+
+1. Validate outbound Spotify traffic (method, URL/query, body, auth) — often with Zod parsers in `e2e/schemas/`
+2. Assert the matching UI outcome via `data-testid`
+
+Default Spotify routes stay mocked for CI speed. Synthetic edge cases (401, 500, delayed responses) must include a `// [QA_AUDIT_REQUIRED]: ...` justification.
+
 ### Unit Tests (Vitest)
 
 ```bash
@@ -131,7 +170,7 @@ npm test
 
 ### End-to-End Tests (Playwright)
 
-Playwright tests mock all Spotify API calls, so no credentials are required.
+Playwright tests mock all Spotify API calls, so no credentials are required. Specs use page objects under `e2e/pages/`; assertions stay in `*.spec.ts`.
 
 **Local development** (Vite dev server at `/cc_jammming_music/`):
 

--- a/e2e/api/auth.spec.ts
+++ b/e2e/api/auth.spec.ts
@@ -9,6 +9,13 @@ import {
   mockSpotifyTokenExchange,
 } from '../fixtures/auth';
 import { mockSpotifyApi } from '../fixtures/mock-spotify-api';
+import {
+  trackUrlHits,
+  waitForSearchRequest,
+  waitForTokenExchangeRequest,
+} from '../fixtures/request-tracking';
+import { SearchPage } from '../pages';
+import { parseTokenExchangeForm } from '../schemas/validate';
 import { PKCE_CODE_VERIFIER_STORAGE_KEY } from '../../src/util/pkce';
 
 test.describe('Spotify auth', () => {
@@ -32,15 +39,15 @@ test.describe('Spotify auth', () => {
       },
     );
 
-    const tokenRequest = page.waitForRequest(
-      '**/accounts.spotify.com/api/token**',
-    );
+    const tokenRequest = waitForTokenExchangeRequest(page);
     await page.goto(`${baseURL}/?code=${MOCK_AUTH_CODE}`);
 
     const tokenExchange = await tokenRequest;
     expect(tokenExchange.method()).toBe('POST');
-    expect(tokenExchange.postData()).toContain('grant_type=authorization_code');
-    expect(tokenExchange.postData()).toContain(`code=${MOCK_AUTH_CODE}`);
+    expect(parseTokenExchangeForm(tokenExchange.postData())).toMatchObject({
+      grant_type: 'authorization_code',
+      code: MOCK_AUTH_CODE,
+    });
 
     await context.close();
   });
@@ -48,11 +55,10 @@ test.describe('Spotify auth', () => {
   test('sends bearer token on search requests after PKCE callback bootstrap', async ({
     page,
   }) => {
-    // Bootstrap already exchanged the auth code during fixture setup.
-    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
+    const search = new SearchPage(page);
+    const searchRequest = waitForSearchRequest(page);
 
-    await page.getByTestId('search-by-input').fill('test song');
-    await page.getByTestId('search-button').click();
+    await search.fillAndSearch('test song');
 
     const request = await searchRequest;
     expect(request.headers().authorization).toBe(`Bearer ${MOCK_ACCESS_TOKEN}`);
@@ -61,18 +67,15 @@ test.describe('Spotify auth', () => {
   test('does not redirect to Spotify accounts during mocked tests', async ({
     page,
   }) => {
-    let authorizeRequested = false;
+    const search = new SearchPage(page);
+    const authorizeHits = trackUrlHits(
+      page,
+      'accounts.spotify.com/authorize',
+    );
 
-    page.on('request', (request) => {
-      if (request.url().includes('accounts.spotify.com/authorize')) {
-        authorizeRequested = true;
-      }
-    });
+    await search.fillAndSearch('test song');
 
-    await page.getByTestId('search-by-input').fill('test song');
-    await page.getByTestId('search-button').click();
-
-    await expect(page.getByTestId('track-item-track-1')).toBeVisible();
-    expect(authorizeRequested).toBe(false);
+    await expect(search.trackItem('track-1')).toBeVisible();
+    expect(authorizeHits.count()).toBe(0);
   });
 });

--- a/e2e/api/save-playlist.spec.ts
+++ b/e2e/api/save-playlist.spec.ts
@@ -1,75 +1,96 @@
-import type { Page } from '@playwright/test';
 import { test, expect } from '../fixtures/test';
 import { mockSpotifyApi } from '../fixtures/mock-spotify-api';
 import { mockPlaylist, mockTracks, mockUser } from '../fixtures/spotify-mocks';
-
-async function searchAndAddFirstTrack(page: Page) {
-  await page.getByTestId('search-by-input').fill('test song');
-  await page.getByTestId('search-button').click();
-  await expect(page.getByTestId('track-item-track-1')).toBeVisible();
-  await page.getByTestId('track-add-track-1').click();
-  await expect(page.getByTestId('track-item-track-1')).toHaveCount(2);
-}
+import {
+  waitForAddTracksRequest,
+  waitForCreatePlaylistRequest,
+  waitForMeRequest,
+} from '../fixtures/request-tracking';
+import { AppPage } from '../pages';
+import {
+  parseAddTracksRequest,
+  parseCreatePlaylistRequest,
+} from '../schemas/validate';
 
 test.describe('Spotify save playlist API', () => {
-  test('calls me, create playlist, and add tracks in order', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
+  test('calls me, create playlist, and add tracks in order', async ({
+    page,
+  }) => {
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
+    await app.playlist.fillTitle('My Test Playlist');
 
-    await page.getByTestId('playlist-title-input').fill('My Test Playlist');
-
-    const meRequest = page.waitForRequest('**/api.spotify.com/v1/me');
-    const createPlaylistRequest = page.waitForRequest(
-      (request) =>
-        request.method() === 'POST' &&
-        request.url().includes(`/v1/users/${mockUser.id}/playlists`) &&
-        !request.url().includes('/tracks')
+    const meRequest = waitForMeRequest(page);
+    const createPlaylistRequest = waitForCreatePlaylistRequest(
+      page,
+      mockUser.id,
     );
-    const addTracksRequest = page.waitForRequest(
-      (request) =>
-        request.method() === 'POST' &&
-        request.url().includes(`/playlists/${mockPlaylist.id}/tracks`)
-    );
+    const addTracksRequest = waitForAddTracksRequest(page, mockPlaylist.id);
 
-    await page.getByTestId('save-playlist-button').click();
+    await app.playlist.clickSave();
 
     const me = await meRequest;
     const createPlaylist = await createPlaylistRequest;
     const addTracks = await addTracksRequest;
 
     expect(me.method()).toBe('GET');
-    expect(createPlaylist.postDataJSON()).toEqual({ name: 'My Test Playlist' });
-    expect(addTracks.postDataJSON()).toEqual({
+    expect(parseCreatePlaylistRequest(createPlaylist.postDataJSON())).toEqual({
+      name: 'My Test Playlist',
+    });
+    expect(parseAddTracksRequest(addTracks.postDataJSON())).toEqual({
       uris: [mockTracks[0].uri],
     });
 
-    expect(me.headers().authorization).toBe(createPlaylist.headers().authorization);
-    expect(createPlaylist.headers().authorization).toBe(addTracks.headers().authorization);
+    expect(me.headers().authorization).toBe(
+      createPlaylist.headers().authorization,
+    );
+    expect(createPlaylist.headers().authorization).toBe(
+      addTracks.headers().authorization,
+    );
   });
 
-  test('returns 201 and clears playlist on successful save', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
+  test('returns 201 and clears playlist on successful save', async ({
+    page,
+  }) => {
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
 
-    await page.getByTestId('playlist-title-input').fill('My Test Playlist');
-    await page.getByTestId('save-playlist-button').click();
+    const meRequest = waitForMeRequest(page);
+    const createPlaylistRequest = waitForCreatePlaylistRequest(
+      page,
+      mockUser.id,
+    );
+    const addTracksRequest = waitForAddTracksRequest(page, mockPlaylist.id);
 
-    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
-    await expect(page.getByTestId('playlist-title-input')).toHaveValue('');
-    await expect(page.getByTestId('track-remove-track-1')).not.toBeVisible();
+    await app.playlist.savePlaylist('My Test Playlist');
+    await meRequest;
+    await createPlaylistRequest;
+    await addTracksRequest;
+
+    await expect(app.playlist.message()).toHaveText('Playlist created');
+    await expect(app.playlist.titleInput()).toHaveValue('');
+    await expect(app.playlist.trackRemoveButton('track-1')).not.toBeVisible();
   });
 
   test('shows error message when create playlist fails', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await page.getByTestId('playlist-title-input').fill('Failed Playlist');
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
+    await app.playlist.fillTitle('Failed Playlist');
+    // [QA_AUDIT_REQUIRED]: Mocking create playlist 500. Cannot force Spotify server errors in CI.
     await mockSpotifyApi(page, { createPlaylistStatus: 500 });
 
-    await page.getByTestId('save-playlist-button').click();
-
-    await expect(page.getByTestId('playlist-message')).toHaveText(
-      'Unable to save playlist. Please try again.'
+    const createPlaylistRequest = waitForCreatePlaylistRequest(
+      page,
+      mockUser.id,
     );
-    await expect(page.getByTestId('playlist-title-input')).toHaveValue('Failed Playlist');
-    await expect(
-      page.getByTestId('playlist-section').getByTestId('track-remove-track-1')
-    ).toBeVisible();
+
+    await app.playlist.clickSave();
+    await createPlaylistRequest;
+
+    await expect(app.playlist.message()).toHaveText(
+      'Unable to save playlist. Please try again.',
+    );
+    await expect(app.playlist.titleInput()).toHaveValue('Failed Playlist');
+    await expect(app.playlist.trackRemoveButton('track-1')).toBeVisible();
   });
 });

--- a/e2e/api/search.spec.ts
+++ b/e2e/api/search.spec.ts
@@ -3,53 +3,64 @@ import { test } from '../fixtures/test';
 import { bootstrapSpotifyAuth } from '../fixtures/auth';
 import { mockSpotifyApi } from '../fixtures/mock-spotify-api';
 import { mockTracks } from '../fixtures/spotify-mocks';
+import {
+  trackUrlHits,
+  waitForSearchRequest,
+} from '../fixtures/request-tracking';
+import { SearchPage } from '../pages';
+import { parseSearchQuery } from '../schemas/validate';
 
 test.describe('Spotify search API', () => {
-  test('requests search with query and renders mapped tracks', async ({ page }) => {
-    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
+  test('requests search with query and renders mapped tracks', async ({
+    page,
+  }) => {
+    const search = new SearchPage(page);
+    const searchRequest = waitForSearchRequest(page);
 
-    await page.getByTestId('search-by-input').fill('test song');
-    await page.getByTestId('search-button').click();
+    await search.fillAndSearch('test song');
 
     const request = await searchRequest;
-    expect(request.method()).toBe('GET');
-    expect(request.url()).toContain('/v1/search');
-    expect(request.url()).toContain('type=track');
-    expect(request.url()).toContain('q=test');
+    const url = new URL(request.url());
 
-    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
-    await expect(page.getByTestId('track-artist-track-1')).toHaveText(
-      mockTracks[0].artists[0].name
+    expect(request.method()).toBe('GET');
+    expect(url.pathname).toContain('/v1/search');
+    expect(url.searchParams.get('type')).toBe('track');
+    expect(parseSearchQuery(url.searchParams.get('q'))).toBe('test song');
+
+    await expect(search.trackName('track-1')).toHaveText(mockTracks[0].name);
+    await expect(search.trackArtist('track-1')).toHaveText(
+      mockTracks[0].artists[0].name,
     );
-    await expect(page.getByTestId('track-name-track-2')).toHaveText(mockTracks[1].name);
+    await expect(search.trackName('track-2')).toHaveText(mockTracks[1].name);
   });
 
   test('does not call search API when query is empty', async ({ page }) => {
-    let searchCalled = false;
+    const search = new SearchPage(page);
+    const searchHits = trackUrlHits(page, '/v1/search');
 
-    page.on('request', (request) => {
-      if (request.url().includes('/v1/search')) {
-        searchCalled = true;
-      }
-    });
+    await search.clickSearch();
 
-    await page.getByTestId('search-button').click();
-
-    expect(searchCalled).toBe(false);
-    await expect(page.getByTestId('search-error')).toHaveText('Please enter a song title');
+    expect(searchHits.count()).toBe(0);
+    await expect(search.searchError()).toHaveText('Please enter a song title');
   });
 });
 
 base.describe('Spotify search API errors', () => {
-  base('returns no tracks when search responds with 401', async ({ page, baseURL }) => {
+  base('returns no tracks when search responds with 401', async ({
+    page,
+    baseURL,
+  }) => {
+    // [QA_AUDIT_REQUIRED]: Mocking search 401. Cannot force Spotify auth failures in CI.
     await mockSpotifyApi(page, { searchStatus: 401 });
     await bootstrapSpotifyAuth(page, baseURL!);
+    const search = new SearchPage(page);
+    const searchRequest = waitForSearchRequest(page);
 
-    await page.getByTestId('search-by-input').fill('test song');
-    await page.getByTestId('search-button').click();
+    await search.fillAndSearch('test song');
+    await searchRequest;
 
-    await expect(page.getByTestId('track-item-track-1')).not.toBeVisible();
-    await expect(page.getByTestId('track-item-track-2')).not.toBeVisible();
-    await expect(page.getByTestId('search-empty-message')).toHaveText('No results found');
+    await expect(search.trackItem('track-1')).not.toBeVisible();
+    await expect(search.trackItem('track-2')).not.toBeVisible();
+    await expect(search.searchEmptyMessage()).toHaveText('No results found');
   });
 });

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -1,26 +1,4 @@
 import type { Page } from '@playwright/test';
-import { AppPage, PlaylistPage, SearchPage } from '../pages';
-
-/**
- * Flow helpers for specs not yet migrated to page objects (Batch 4).
- * Actions / measurements only — put `expect` in `*.spec.ts`.
- * Prefer SearchPage / PlaylistPage / AppPage directly when migrating.
- */
-
-export async function searchTracks(page: Page, query = 'test song') {
-  const search = new SearchPage(page);
-  await search.fillAndSearch(query);
-}
-
-export async function searchAndAddFirstTrack(page: Page) {
-  const app = new AppPage(page);
-  await app.searchAndAddTrack();
-}
-
-export async function savePlaylist(page: Page, name: string) {
-  const playlist = new PlaylistPage(page);
-  await playlist.savePlaylist(name);
-}
 
 /** Returns whether the document scrolls wider than the viewport. No assertion. */
 export async function hasHorizontalOverflow(page: Page): Promise<boolean> {

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -1,41 +1,32 @@
 import type { Page } from '@playwright/test';
-import { expect } from '@playwright/test';
+import { AppPage, PlaylistPage, SearchPage } from '../pages';
+
+/**
+ * Flow helpers for specs not yet migrated to page objects (Batch 4).
+ * Actions / measurements only — put `expect` in `*.spec.ts`.
+ * Prefer SearchPage / PlaylistPage / AppPage directly when migrating.
+ */
 
 export async function searchTracks(page: Page, query = 'test song') {
-  await page.getByTestId('search-by-input').fill(query);
-  await page.getByTestId('search-button').click();
-  await expect(page.getByTestId('track-item-track-1')).toBeVisible();
+  const search = new SearchPage(page);
+  await search.fillAndSearch(query);
 }
 
 export async function searchAndAddFirstTrack(page: Page) {
-  await searchTracks(page);
-  await page.getByTestId('track-add-track-1').click();
-  await expect(
-    page.getByTestId('playlist-section').getByTestId('track-remove-track-1')
-  ).toBeVisible();
+  const app = new AppPage(page);
+  await app.searchAndAddTrack();
 }
 
 export async function savePlaylist(page: Page, name: string) {
-  await page.getByTestId('playlist-title-input').fill(name);
-  await page.getByTestId('save-playlist-button').click();
+  const playlist = new PlaylistPage(page);
+  await playlist.savePlaylist(name);
 }
 
-export async function expectNoHorizontalOverflow(page: Page) {
-  const hasOverflow = await page.evaluate(
-    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+/** Returns whether the document scrolls wider than the viewport. No assertion. */
+export async function hasHorizontalOverflow(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () =>
+      document.documentElement.scrollWidth >
+      document.documentElement.clientWidth,
   );
-  expect(hasOverflow).toBe(false);
-}
-
-export async function expectMatchingControlWidths(
-  page: Page,
-  firstTestId: string,
-  secondTestId: string,
-) {
-  const firstBox = await page.getByTestId(firstTestId).boundingBox();
-  const secondBox = await page.getByTestId(secondTestId).boundingBox();
-
-  expect(firstBox).not.toBeNull();
-  expect(secondBox).not.toBeNull();
-  expect(secondBox!.width).toBeCloseTo(firstBox!.width, 0);
 }

--- a/e2e/fixtures/mock-spotify-api.ts
+++ b/e2e/fixtures/mock-spotify-api.ts
@@ -1,5 +1,10 @@
 import type { Page, Route } from '@playwright/test';
 import {
+  parseSpotifyPlaylistResponse,
+  parseSpotifySearchResponse,
+  parseSpotifyUserResponse,
+} from '../schemas/validate';
+import {
   MOCK_ACCESS_TOKEN,
   mockPlaylist,
   mockSearchResponse,
@@ -30,6 +35,14 @@ function createReleaseGate() {
   return { gate, release: () => release() };
 }
 
+function fulfillJson(route: Route, status: number, body: unknown) {
+  return route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
 export async function mockSpotifyApi(page: Page, options: MockOptions = {}) {
   const {
     searchStatus = 200,
@@ -44,34 +57,47 @@ export async function mockSpotifyApi(page: Page, options: MockOptions = {}) {
     const auth = route.request().headers().authorization;
 
     if (auth !== `Bearer ${MOCK_ACCESS_TOKEN}`) {
+      // [QA_AUDIT_REQUIRED]: Mocking 401 for missing/invalid Bearer. Cannot force Spotify auth failures in CI.
       return route.fulfill({ status: 401, body: '{}' });
     }
 
     if (url.includes('/v1/search') && method === 'GET') {
-      return route.fulfill({
-        status: searchStatus,
-        contentType: 'application/json',
-        body: JSON.stringify(searchStatus === 200 ? mockSearchResponse : {}),
-      });
+      if (searchStatus !== 200) {
+        // [QA_AUDIT_REQUIRED]: Mocking non-200 search (e.g. 401/500). Cannot force Spotify search errors in CI.
+        return fulfillJson(route, searchStatus, {});
+      }
+      return fulfillJson(
+        route,
+        searchStatus,
+        parseSpotifySearchResponse(mockSearchResponse),
+      );
     }
 
     if (url.endsWith('/v1/me') && method === 'GET') {
-      return route.fulfill({
-        status: meStatus,
-        contentType: 'application/json',
-        body: JSON.stringify(meStatus === 200 ? mockUser : {}),
-      });
+      if (meStatus !== 200) {
+        // [QA_AUDIT_REQUIRED]: Mocking non-200 /v1/me. Cannot force Spotify profile errors in CI.
+        return fulfillJson(route, meStatus, {});
+      }
+      return fulfillJson(route, meStatus, parseSpotifyUserResponse(mockUser));
     }
 
     if (url.includes('/playlists') && method === 'POST' && !url.includes('/tracks')) {
-      return route.fulfill({
-        status: createPlaylistStatus,
-        contentType: 'application/json',
-        body: JSON.stringify(createPlaylistStatus === 201 ? mockPlaylist : {}),
-      });
+      if (createPlaylistStatus !== 201) {
+        // [QA_AUDIT_REQUIRED]: Mocking non-201 create playlist (e.g. 500). Cannot force Spotify server errors in CI.
+        return fulfillJson(route, createPlaylistStatus, {});
+      }
+      return fulfillJson(
+        route,
+        createPlaylistStatus,
+        parseSpotifyPlaylistResponse(mockPlaylist),
+      );
     }
 
     if (url.includes('/playlists/') && url.endsWith('/tracks') && method === 'POST') {
+      if (addTracksStatus !== 201) {
+        // [QA_AUDIT_REQUIRED]: Mocking non-201 add tracks. Cannot force Spotify track-add errors in CI.
+        return route.fulfill({ status: addTracksStatus, body: '' });
+      }
       return route.fulfill({ status: addTracksStatus, body: '' });
     }
 
@@ -81,30 +107,32 @@ export async function mockSpotifyApi(page: Page, options: MockOptions = {}) {
 
 export async function mockEmptySearchResults(page: Page) {
   await page.route('**/api.spotify.com/v1/search*', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ tracks: { items: [] } }),
-    });
+    await fulfillJson(
+      route,
+      200,
+      parseSpotifySearchResponse({ tracks: { items: [] } }),
+    );
   });
 }
 
 export async function mockDelayedSearch(page: Page): Promise<DelayedControl> {
+  // [QA_AUDIT_REQUIRED]: Artificial delay gate for loading UI. Cannot control Spotify latency in CI.
   const { gate, release } = createReleaseGate();
 
   await page.route('**/api.spotify.com/v1/search*', async (route) => {
     await gate;
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(mockSearchResponse),
-    });
+    await fulfillJson(
+      route,
+      200,
+      parseSpotifySearchResponse(mockSearchResponse),
+    );
   });
 
   return { release };
 }
 
 export async function mockDelayedSave(page: Page): Promise<DelayedSaveControl> {
+  // [QA_AUDIT_REQUIRED]: Artificial delay on /v1/me during save for loading UI. Cannot control Spotify latency in CI.
   const { gate, release } = createReleaseGate();
   let blockMe = false;
 
@@ -114,34 +142,31 @@ export async function mockDelayedSave(page: Page): Promise<DelayedSaveControl> {
     const auth = route.request().headers().authorization;
 
     if (auth !== `Bearer ${MOCK_ACCESS_TOKEN}`) {
+      // [QA_AUDIT_REQUIRED]: Mocking 401 for missing/invalid Bearer. Cannot force Spotify auth failures in CI.
       return route.fulfill({ status: 401, body: '{}' });
     }
 
     if (url.includes('/v1/search') && method === 'GET') {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(mockSearchResponse),
-      });
+      return fulfillJson(
+        route,
+        200,
+        parseSpotifySearchResponse(mockSearchResponse),
+      );
     }
 
     if (url.endsWith('/v1/me') && method === 'GET') {
       if (blockMe) {
         await gate;
       }
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(mockUser),
-      });
+      return fulfillJson(route, 200, parseSpotifyUserResponse(mockUser));
     }
 
     if (url.includes('/playlists') && method === 'POST' && !url.includes('/tracks')) {
-      return route.fulfill({
-        status: 201,
-        contentType: 'application/json',
-        body: JSON.stringify(mockPlaylist),
-      });
+      return fulfillJson(
+        route,
+        201,
+        parseSpotifyPlaylistResponse(mockPlaylist),
+      );
     }
 
     if (url.includes('/playlists/') && url.endsWith('/tracks') && method === 'POST') {

--- a/e2e/fixtures/request-tracking.ts
+++ b/e2e/fixtures/request-tracking.ts
@@ -1,0 +1,54 @@
+import type { Page, Request } from '@playwright/test';
+
+export type UrlHitTracker = {
+  count: () => number;
+  urls: () => string[];
+};
+
+/**
+ * Counts requests whose URL includes `urlSubstring`.
+ * Put branching here — not in `*.spec.ts`.
+ */
+export function trackUrlHits(page: Page, urlSubstring: string): UrlHitTracker {
+  const hits: string[] = [];
+
+  page.on('request', (request: Request) => {
+    if (request.url().includes(urlSubstring)) {
+      hits.push(request.url());
+    }
+  });
+
+  return {
+    count: () => hits.length,
+    urls: () => [...hits],
+  };
+}
+
+export function waitForTokenExchangeRequest(page: Page) {
+  return page.waitForRequest('**/accounts.spotify.com/api/token**');
+}
+
+export function waitForSearchRequest(page: Page) {
+  return page.waitForRequest('**/api.spotify.com/v1/search*');
+}
+
+export function waitForMeRequest(page: Page) {
+  return page.waitForRequest('**/api.spotify.com/v1/me');
+}
+
+export function waitForCreatePlaylistRequest(page: Page, userId: string) {
+  return page.waitForRequest(
+    (request) =>
+      request.method() === 'POST' &&
+      request.url().includes(`/v1/users/${userId}/playlists`) &&
+      !request.url().includes('/tracks'),
+  );
+}
+
+export function waitForAddTracksRequest(page: Page, playlistId: string) {
+  return page.waitForRequest(
+    (request) =>
+      request.method() === 'POST' &&
+      request.url().includes(`/playlists/${playlistId}/tracks`),
+  );
+}

--- a/e2e/fixtures/spotify-mocks.ts
+++ b/e2e/fixtures/spotify-mocks.ts
@@ -1,21 +1,29 @@
+import {
+  parseSpotifyPlaylistResponse,
+  parseSpotifySearchResponse,
+  parseSpotifyTokenResponse,
+  parseSpotifyUserResponse,
+  parseTracks,
+} from '../schemas/validate';
+
 export const MOCK_ACCESS_TOKEN = 'mock-access-token';
 export const MOCK_AUTH_CODE = 'mock-auth-code';
 export const MOCK_PKCE_CODE_VERIFIER =
   'e2e-pkce-verifier-abcdefghijklmnopqrstuvwxyz123456';
 
-export const mockTokenResponse = {
+export const mockTokenResponse = parseSpotifyTokenResponse({
   access_token: MOCK_ACCESS_TOKEN,
   token_type: 'Bearer',
   scope: 'playlist-modify-public',
   expires_in: 3600,
-};
+});
 
-export const mockUser = {
+export const mockUser = parseSpotifyUserResponse({
   id: 'test-user-id',
   display_name: 'Test User',
-};
+});
 
-export const mockTracks = [
+const mockTracksRaw = [
   {
     id: 'track-1',
     name: 'Test Song One',
@@ -32,22 +40,26 @@ export const mockTracks = [
   },
 ];
 
-export const mockSearchResponse = {
+export const mockSearchResponse = parseSpotifySearchResponse({
   tracks: {
-    items: mockTracks,
+    items: mockTracksRaw,
   },
-};
+});
 
-export const mockPlaylist = {
+export const mockTracks = mockSearchResponse.tracks!.items;
+
+export const mockPlaylist = parseSpotifyPlaylistResponse({
   id: 'playlist-123',
   name: 'Test Playlist',
   uri: 'spotify:playlist:playlist-123',
-};
+});
 
-export const mappedMockTracks = mockTracks.map((track) => ({
-  id: track.id,
-  name: track.name,
-  artist: track.artists[0].name,
-  album: track.album.name,
-  uri: track.uri,
-}));
+export const mappedMockTracks = parseTracks(
+  mockTracks.map((track) => ({
+    id: track.id,
+    name: track.name,
+    artist: track.artists[0].name,
+    album: track.album.name,
+    uri: track.uri,
+  })),
+);

--- a/e2e/pages/AppPage.ts
+++ b/e2e/pages/AppPage.ts
@@ -1,0 +1,27 @@
+import type { Page } from '@playwright/test';
+import { BasePage } from './BasePage';
+import { PlaylistPage } from './PlaylistPage';
+import { SearchPage } from './SearchPage';
+import { selectors } from './selectors';
+
+/** Thin facade composing Search + Playlist page objects. No assertions. */
+export class AppPage extends BasePage {
+  readonly search: SearchPage;
+  readonly playlist: PlaylistPage;
+
+  constructor(page: Page) {
+    super(page);
+    this.search = new SearchPage(page);
+    this.playlist = new PlaylistPage(page);
+  }
+
+  spotifyConfigError() {
+    return this.page.getByTestId(selectors.spotifyConfigError);
+  }
+
+  /** Search and add a track by id (default: first mock track). */
+  async searchAndAddTrack(query = 'test song', trackId = 'track-1') {
+    await this.search.fillAndSearch(query);
+    await this.search.clickAddTrack(trackId);
+  }
+}

--- a/e2e/pages/BasePage.ts
+++ b/e2e/pages/BasePage.ts
@@ -1,0 +1,15 @@
+import type { Page, Locator } from '@playwright/test';
+import { selectors } from './selectors';
+
+/** Shared navigation and locators for Jammming pages. No assertions. */
+export class BasePage {
+  constructor(protected readonly page: Page) {}
+
+  async goto(path = '/') {
+    await this.page.goto(path);
+  }
+
+  playlistSection(): Locator {
+    return this.page.getByTestId(selectors.playlistSection);
+  }
+}

--- a/e2e/pages/BasePage.ts
+++ b/e2e/pages/BasePage.ts
@@ -12,4 +12,8 @@ export class BasePage {
   playlistSection(): Locator {
     return this.page.getByTestId(selectors.playlistSection);
   }
+
+  appTitle(): Locator {
+    return this.page.getByTestId(selectors.appTitle);
+  }
 }

--- a/e2e/pages/PlaylistPage.ts
+++ b/e2e/pages/PlaylistPage.ts
@@ -1,0 +1,51 @@
+import type { Locator } from '@playwright/test';
+import { BasePage } from './BasePage';
+import { selectors } from './selectors';
+
+/** Playlist panel actions and locators. No assertions. */
+export class PlaylistPage extends BasePage {
+  titleInput(): Locator {
+    return this.page.getByTestId(selectors.playlistTitleInput);
+  }
+
+  saveButton(): Locator {
+    return this.page.getByTestId(selectors.savePlaylistButton);
+  }
+
+  message(): Locator {
+    return this.page.getByTestId(selectors.playlistMessage);
+  }
+
+  validationError(): Locator {
+    return this.page.getByTestId(selectors.playlistValidationError);
+  }
+
+  trackInPlaylist(id: string): Locator {
+    return this.playlistSection().getByTestId(selectors.trackItem(id));
+  }
+
+  trackNameInPlaylist(id: string): Locator {
+    return this.playlistSection().getByTestId(selectors.trackName(id));
+  }
+
+  trackRemoveButton(id: string): Locator {
+    return this.playlistSection().getByTestId(selectors.trackRemove(id));
+  }
+
+  async fillTitle(name: string) {
+    await this.titleInput().fill(name);
+  }
+
+  async clickSave() {
+    await this.saveButton().click();
+  }
+
+  async savePlaylist(name: string) {
+    await this.fillTitle(name);
+    await this.clickSave();
+  }
+
+  async clickRemoveTrack(id: string) {
+    await this.trackRemoveButton(id).click();
+  }
+}

--- a/e2e/pages/SearchPage.ts
+++ b/e2e/pages/SearchPage.ts
@@ -1,0 +1,68 @@
+import type { Locator } from '@playwright/test';
+import { BasePage } from './BasePage';
+import { selectors } from './selectors';
+
+/** Search panel actions and locators. No assertions. */
+export class SearchPage extends BasePage {
+  searchForm(): Locator {
+    return this.page.getByTestId(selectors.searchForm);
+  }
+
+  searchInput(): Locator {
+    return this.page.getByTestId(selectors.searchInput);
+  }
+
+  searchButton(): Locator {
+    return this.page.getByTestId(selectors.searchButton);
+  }
+
+  searchError(): Locator {
+    return this.page.getByTestId(selectors.searchError);
+  }
+
+  searchEmptyMessage(): Locator {
+    return this.page.getByTestId(selectors.searchEmptyMessage);
+  }
+
+  searchApiError(): Locator {
+    return this.page.getByTestId(selectors.searchApiError);
+  }
+
+  trackItem(id: string): Locator {
+    return this.page.getByTestId(selectors.trackItem(id));
+  }
+
+  trackName(id: string): Locator {
+    return this.page.getByTestId(selectors.trackName(id));
+  }
+
+  trackArtist(id: string): Locator {
+    return this.page.getByTestId(selectors.trackArtist(id));
+  }
+
+  trackAddButton(id: string): Locator {
+    return this.page.getByTestId(selectors.trackAdd(id));
+  }
+
+  async fillSearch(query: string) {
+    await this.searchInput().fill(query);
+  }
+
+  async clickSearch() {
+    await this.searchButton().click();
+  }
+
+  async fillAndSearch(query: string) {
+    await this.fillSearch(query);
+    await this.clickSearch();
+  }
+
+  async submitSearchWithEnter(query: string) {
+    await this.fillSearch(query);
+    await this.searchInput().press('Enter');
+  }
+
+  async clickAddTrack(id: string) {
+    await this.trackAddButton(id).click();
+  }
+}

--- a/e2e/pages/SearchPage.ts
+++ b/e2e/pages/SearchPage.ts
@@ -8,6 +8,10 @@ export class SearchPage extends BasePage {
     return this.page.getByTestId(selectors.searchForm);
   }
 
+  searchLabel(): Locator {
+    return this.page.getByTestId(selectors.searchLabel);
+  }
+
   searchInput(): Locator {
     return this.page.getByTestId(selectors.searchInput);
   }
@@ -26,6 +30,10 @@ export class SearchPage extends BasePage {
 
   searchApiError(): Locator {
     return this.page.getByTestId(selectors.searchApiError);
+  }
+
+  resultsHeading(): Locator {
+    return this.page.getByTestId(selectors.resultsHeading);
   }
 
   trackItem(id: string): Locator {

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -1,0 +1,5 @@
+export { BasePage } from './BasePage';
+export { SearchPage } from './SearchPage';
+export { PlaylistPage } from './PlaylistPage';
+export { AppPage } from './AppPage';
+export { selectors } from './selectors';

--- a/e2e/pages/selectors.ts
+++ b/e2e/pages/selectors.ts
@@ -1,0 +1,23 @@
+/** Central registry of `data-testid` strings used by Playwright page objects. */
+
+export const selectors = {
+  searchForm: 'search-form',
+  searchInput: 'search-by-input',
+  searchButton: 'search-button',
+  searchError: 'search-error',
+  searchEmptyMessage: 'search-empty-message',
+  searchApiError: 'search-api-error',
+  spotifyConfigError: 'spotify-config-error',
+
+  playlistSection: 'playlist-section',
+  playlistTitleInput: 'playlist-title-input',
+  playlistMessage: 'playlist-message',
+  playlistValidationError: 'playlist-validation-error',
+  savePlaylistButton: 'save-playlist-button',
+
+  trackItem: (id: string) => `track-item-${id}`,
+  trackName: (id: string) => `track-name-${id}`,
+  trackArtist: (id: string) => `track-artist-${id}`,
+  trackAdd: (id: string) => `track-add-${id}`,
+  trackRemove: (id: string) => `track-remove-${id}`,
+} as const;

--- a/e2e/pages/selectors.ts
+++ b/e2e/pages/selectors.ts
@@ -1,12 +1,16 @@
 /** Central registry of `data-testid` strings used by Playwright page objects. */
 
 export const selectors = {
+  appTitle: 'app-title',
+
   searchForm: 'search-form',
+  searchLabel: 'search-label',
   searchInput: 'search-by-input',
   searchButton: 'search-button',
   searchError: 'search-error',
   searchEmptyMessage: 'search-empty-message',
   searchApiError: 'search-api-error',
+  resultsHeading: 'results-heading',
   spotifyConfigError: 'spotify-config-error',
 
   playlistSection: 'playlist-section',

--- a/e2e/schemas/spotify.ts
+++ b/e2e/schemas/spotify.ts
@@ -69,6 +69,18 @@ export const addTracksRequestSchema = z.object({
   uris: z.array(z.string()).min(1),
 });
 
+/** PKCE token exchange form body (application/x-www-form-urlencoded). */
+export const tokenExchangeFormSchema = z.object({
+  grant_type: z.literal('authorization_code'),
+  code: z.string().min(1),
+  code_verifier: z.string().optional(),
+  redirect_uri: z.string().optional(),
+  client_id: z.string().optional(),
+});
+
+/** Search query string from GET /v1/search `q` param. */
+export const searchQuerySchema = z.string().min(1);
+
 export type SpotifySearchResponse = z.infer<typeof spotifySearchResponseSchema>;
 export type SpotifyUserResponse = z.infer<typeof spotifyUserResponseSchema>;
 export type SpotifyPlaylistResponse = z.infer<typeof spotifyPlaylistResponseSchema>;
@@ -76,3 +88,4 @@ export type SpotifyTokenResponse = z.infer<typeof spotifyTokenResponseSchema>;
 export type Track = z.infer<typeof trackSchema>;
 export type CreatePlaylistRequest = z.infer<typeof createPlaylistRequestSchema>;
 export type AddTracksRequest = z.infer<typeof addTracksRequestSchema>;
+export type TokenExchangeForm = z.infer<typeof tokenExchangeFormSchema>;

--- a/e2e/schemas/spotify.ts
+++ b/e2e/schemas/spotify.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+/** Spotify Web API artist (subset used by Jammming). */
+export const spotifyArtistSchema = z.object({
+  name: z.string(),
+});
+
+/** Spotify Web API album (subset used by Jammming). */
+export const spotifyAlbumSchema = z.object({
+  name: z.string(),
+});
+
+/** Spotify Web API track item from search results. */
+export const spotifyApiTrackSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  uri: z.string(),
+  artists: z.array(spotifyArtistSchema).min(1),
+  album: spotifyAlbumSchema,
+});
+
+/** GET /v1/search?type=track response (subset). */
+export const spotifySearchResponseSchema = z.object({
+  tracks: z
+    .object({
+      items: z.array(spotifyApiTrackSchema),
+    })
+    .optional(),
+});
+
+/** GET /v1/me response (subset). */
+export const spotifyUserResponseSchema = z.object({
+  id: z.string(),
+  display_name: z.string().optional(),
+});
+
+/** POST create playlist response (subset). */
+export const spotifyPlaylistResponseSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  uri: z.string().optional(),
+});
+
+/** POST /api/token response (Authorization Code + PKCE). */
+export const spotifyTokenResponseSchema = z.object({
+  access_token: z.string(),
+  token_type: z.string(),
+  scope: z.string(),
+  expires_in: z.number(),
+  refresh_token: z.string().optional(),
+});
+
+/** App-level Track used in UI reconciliation. */
+export const trackSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  artist: z.string(),
+  album: z.string(),
+  uri: z.string(),
+});
+
+/** POST create playlist request body. */
+export const createPlaylistRequestSchema = z.object({
+  name: z.string().min(1),
+});
+
+/** POST add tracks request body. */
+export const addTracksRequestSchema = z.object({
+  uris: z.array(z.string()).min(1),
+});
+
+export type SpotifySearchResponse = z.infer<typeof spotifySearchResponseSchema>;
+export type SpotifyUserResponse = z.infer<typeof spotifyUserResponseSchema>;
+export type SpotifyPlaylistResponse = z.infer<typeof spotifyPlaylistResponseSchema>;
+export type SpotifyTokenResponse = z.infer<typeof spotifyTokenResponseSchema>;
+export type Track = z.infer<typeof trackSchema>;
+export type CreatePlaylistRequest = z.infer<typeof createPlaylistRequestSchema>;
+export type AddTracksRequest = z.infer<typeof addTracksRequestSchema>;

--- a/e2e/schemas/validate.ts
+++ b/e2e/schemas/validate.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import {
+  addTracksRequestSchema,
+  createPlaylistRequestSchema,
+  spotifyPlaylistResponseSchema,
+  spotifySearchResponseSchema,
+  spotifyTokenResponseSchema,
+  spotifyUserResponseSchema,
+  trackSchema,
+  type AddTracksRequest,
+  type CreatePlaylistRequest,
+  type SpotifyPlaylistResponse,
+  type SpotifySearchResponse,
+  type SpotifyTokenResponse,
+  type SpotifyUserResponse,
+  type Track,
+} from './spotify';
+
+function formatZodError(label: string, error: z.ZodError): string {
+  const details = error.issues
+    .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('; ');
+  return `${label} failed contract validation: ${details}`;
+}
+
+function parseWithLabel<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+  label: string,
+): T {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    throw new Error(formatZodError(label, result.error));
+  }
+  return result.data;
+}
+
+/** Assert unknown JSON matches a schema; throws with a labeled message. */
+export function assertContract<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+  label: string,
+): T {
+  return parseWithLabel(schema, data, label);
+}
+
+export function parseSpotifySearchResponse(
+  data: unknown,
+): SpotifySearchResponse {
+  return parseWithLabel(
+    spotifySearchResponseSchema,
+    data,
+    'SpotifySearchResponse',
+  );
+}
+
+export function parseSpotifyUserResponse(data: unknown): SpotifyUserResponse {
+  return parseWithLabel(spotifyUserResponseSchema, data, 'SpotifyUserResponse');
+}
+
+export function parseSpotifyPlaylistResponse(
+  data: unknown,
+): SpotifyPlaylistResponse {
+  return parseWithLabel(
+    spotifyPlaylistResponseSchema,
+    data,
+    'SpotifyPlaylistResponse',
+  );
+}
+
+export function parseSpotifyTokenResponse(data: unknown): SpotifyTokenResponse {
+  return parseWithLabel(
+    spotifyTokenResponseSchema,
+    data,
+    'SpotifyTokenResponse',
+  );
+}
+
+export function parseTrack(data: unknown): Track {
+  return parseWithLabel(trackSchema, data, 'Track');
+}
+
+export function parseTracks(data: unknown): Track[] {
+  return parseWithLabel(z.array(trackSchema), data, 'Track[]');
+}
+
+export function parseCreatePlaylistRequest(
+  data: unknown,
+): CreatePlaylistRequest {
+  return parseWithLabel(
+    createPlaylistRequestSchema,
+    data,
+    'CreatePlaylistRequest',
+  );
+}
+
+export function parseAddTracksRequest(data: unknown): AddTracksRequest {
+  return parseWithLabel(addTracksRequestSchema, data, 'AddTracksRequest');
+}

--- a/e2e/schemas/validate.ts
+++ b/e2e/schemas/validate.ts
@@ -2,10 +2,12 @@ import { z } from 'zod';
 import {
   addTracksRequestSchema,
   createPlaylistRequestSchema,
+  searchQuerySchema,
   spotifyPlaylistResponseSchema,
   spotifySearchResponseSchema,
   spotifyTokenResponseSchema,
   spotifyUserResponseSchema,
+  tokenExchangeFormSchema,
   trackSchema,
   type AddTracksRequest,
   type CreatePlaylistRequest,
@@ -13,6 +15,7 @@ import {
   type SpotifySearchResponse,
   type SpotifyTokenResponse,
   type SpotifyUserResponse,
+  type TokenExchangeForm,
   type Track,
 } from './spotify';
 
@@ -96,4 +99,15 @@ export function parseCreatePlaylistRequest(
 
 export function parseAddTracksRequest(data: unknown): AddTracksRequest {
   return parseWithLabel(addTracksRequestSchema, data, 'AddTracksRequest');
+}
+
+export function parseTokenExchangeForm(
+  postData: string | null,
+): TokenExchangeForm {
+  const params = Object.fromEntries(new URLSearchParams(postData ?? ''));
+  return parseWithLabel(tokenExchangeFormSchema, params, 'TokenExchangeForm');
+}
+
+export function parseSearchQuery(query: string | null): string {
+  return parseWithLabel(searchQuerySchema, query, 'SearchQuery');
 }

--- a/e2e/ui/a11y.spec.ts
+++ b/e2e/ui/a11y.spec.ts
@@ -1,39 +1,54 @@
 import { test, expect } from '../fixtures/test';
 import { mockSpotifyApi } from '../fixtures/mock-spotify-api';
-import { searchAndAddFirstTrack } from '../fixtures/helpers';
+import { AppPage, SearchPage } from '../pages';
 
 test.describe('Accessibility', () => {
-  test('search input has an accessible name', async ({ page }) => {
-    await expect(
-      page.getByRole('textbox', { name: 'Search by song title' })
-    ).toBeVisible();
+  test('search input has an accessible name via labeled control', async ({
+    page,
+  }) => {
+    const search = new SearchPage(page);
+
+    await expect(search.searchLabel()).toHaveText('Search by song title');
+    await expect(search.searchInput()).toHaveAttribute('id', 'search-by-input');
+    await expect(search.searchInput()).toBeVisible();
   });
 
   test('playlist message uses a polite live region', async ({ page }) => {
-    const message = page.getByTestId('playlist-message');
+    const app = new AppPage(page);
+    const message = app.playlist.message();
+
     await expect(message).toHaveAttribute('role', 'status');
     await expect(message).toHaveAttribute('aria-live', 'polite');
   });
 
   test('search validation errors use role alert', async ({ page }) => {
-    await page.getByTestId('search-button').click();
-    await expect(page.getByRole('alert')).toHaveText('Please enter a song title');
+    const search = new SearchPage(page);
+
+    await search.clickSearch();
+
+    await expect(search.searchError()).toHaveAttribute('role', 'alert');
+    await expect(search.searchError()).toHaveText('Please enter a song title');
   });
 
   test('search API errors use role alert', async ({ page }) => {
+    // [QA_AUDIT_REQUIRED]: Mocking search 500. Cannot force Spotify search errors in CI.
     await mockSpotifyApi(page, { searchStatus: 500 });
-    await page.getByRole('textbox', { name: 'Search by song title' }).fill('test');
-    await page.getByTestId('search-button').click();
+    const search = new SearchPage(page);
 
-    await expect(page.getByRole('alert')).toHaveText(
-      'Unable to search right now. Please try again.'
+    await search.fillAndSearch('test');
+
+    await expect(search.searchApiError()).toHaveAttribute('role', 'alert');
+    await expect(search.searchApiError()).toHaveText(
+      'Unable to search right now. Please try again.',
     );
   });
 
   test('playlist status announces duplicate track message', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await page.getByTestId('track-add-track-1').click();
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
+    await app.search.clickAddTrack('track-1');
 
-    await expect(page.getByRole('status')).toHaveText('This song is in the playlist.');
+    await expect(app.playlist.message()).toHaveAttribute('role', 'status');
+    await expect(app.playlist.message()).toHaveText('This song is in the playlist.');
   });
 });

--- a/e2e/ui/loading-states.spec.ts
+++ b/e2e/ui/loading-states.spec.ts
@@ -1,38 +1,42 @@
 import { test, expect } from '../fixtures/test';
 import { mockDelayedSave, mockDelayedSearch } from '../fixtures/mock-spotify-api';
-import { searchAndAddFirstTrack } from '../fixtures/helpers';
+import { AppPage, SearchPage } from '../pages';
 
 test.describe('Loading states', () => {
   test('shows Searching... while search is in progress', async ({ page }) => {
+    // [QA_AUDIT_REQUIRED]: Artificial delay gate for loading UI. Cannot control Spotify latency in CI.
     const { release } = await mockDelayedSearch(page);
+    const search = new SearchPage(page);
 
-    await page.getByTestId('search-by-input').fill('test song');
-    await page.getByTestId('search-button').click();
+    await search.fillSearch('test song');
+    await search.clickSearch();
 
-    await expect(page.getByTestId('search-button')).toHaveText('Searching...');
-    await expect(page.getByTestId('search-button')).toBeDisabled();
+    await expect(search.searchButton()).toHaveText('Searching...');
+    await expect(search.searchButton()).toBeDisabled();
 
     release();
-    await expect(page.getByTestId('track-item-track-1')).toBeVisible();
-    await expect(page.getByTestId('search-button')).toHaveText('Search');
-    await expect(page.getByTestId('search-button')).toBeEnabled();
+    await expect(search.trackItem('track-1')).toBeVisible();
+    await expect(search.searchButton()).toHaveText('Search');
+    await expect(search.searchButton()).toBeEnabled();
   });
 
   test('shows Saving... while save is in progress', async ({ page }) => {
+    // [QA_AUDIT_REQUIRED]: Artificial delay on save for loading UI. Cannot control Spotify latency in CI.
     const { release, arm } = await mockDelayedSave(page);
+    const app = new AppPage(page);
 
-    await searchAndAddFirstTrack(page);
-    await page.getByTestId('playlist-title-input').fill('Weekend Vibes');
+    await app.searchAndAddTrack();
+    await app.playlist.fillTitle('Weekend Vibes');
 
     arm();
-    await page.getByTestId('save-playlist-button').click();
+    await app.playlist.clickSave();
 
-    await expect(page.getByTestId('save-playlist-button')).toHaveText('Saving...');
-    await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
+    await expect(app.playlist.saveButton()).toHaveText('Saving...');
+    await expect(app.playlist.saveButton()).toBeDisabled();
 
     release();
-    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
-    await expect(page.getByTestId('save-playlist-button')).toHaveText('Save to Spotify');
-    await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
+    await expect(app.playlist.message()).toHaveText('Playlist created');
+    await expect(app.playlist.saveButton()).toHaveText('Save to Spotify');
+    await expect(app.playlist.saveButton()).toBeDisabled();
   });
 });

--- a/e2e/ui/mobile/layout.spec.ts
+++ b/e2e/ui/mobile/layout.spec.ts
@@ -1,15 +1,19 @@
 import { test, expect } from '../../fixtures/test';
 import { hasHorizontalOverflow } from '../../fixtures/helpers';
+import { AppPage, SearchPage } from '../../pages';
 
 test.describe('Mobile layout', () => {
   test('loads without horizontal overflow', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Jamming' })).toBeVisible();
+    const app = new AppPage(page);
+
+    await expect(app.appTitle()).toBeVisible();
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 
   test('aligns search button width with search input', async ({ page }) => {
-    const firstBox = await page.getByTestId('search-by-input').boundingBox();
-    const secondBox = await page.getByTestId('search-button').boundingBox();
+    const search = new SearchPage(page);
+    const firstBox = await search.searchInput().boundingBox();
+    const secondBox = await search.searchButton().boundingBox();
 
     expect(firstBox).not.toBeNull();
     expect(secondBox).not.toBeNull();

--- a/e2e/ui/mobile/layout.spec.ts
+++ b/e2e/ui/mobile/layout.spec.ts
@@ -1,16 +1,18 @@
 import { test, expect } from '../../fixtures/test';
-import {
-  expectMatchingControlWidths,
-  expectNoHorizontalOverflow,
-} from '../../fixtures/helpers';
+import { hasHorizontalOverflow } from '../../fixtures/helpers';
 
 test.describe('Mobile layout', () => {
   test('loads without horizontal overflow', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Jamming' })).toBeVisible();
-    await expectNoHorizontalOverflow(page);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 
   test('aligns search button width with search input', async ({ page }) => {
-    await expectMatchingControlWidths(page, 'search-by-input', 'search-button');
+    const firstBox = await page.getByTestId('search-by-input').boundingBox();
+    const secondBox = await page.getByTestId('search-button').boundingBox();
+
+    expect(firstBox).not.toBeNull();
+    expect(secondBox).not.toBeNull();
+    expect(secondBox!.width).toBeCloseTo(firstBox!.width, 0);
   });
 });

--- a/e2e/ui/mobile/remove-track.spec.ts
+++ b/e2e/ui/mobile/remove-track.spec.ts
@@ -1,16 +1,19 @@
 import { test, expect } from '../../fixtures/test';
-import { hasHorizontalOverflow, searchAndAddFirstTrack } from '../../fixtures/helpers';
+import { hasHorizontalOverflow } from '../../fixtures/helpers';
+import { AppPage } from '../../pages';
 
 test.describe('Mobile remove track', () => {
-  test('removes a track and disables save when playlist is empty', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await page.getByTestId('playlist-title-input').fill('Solo Track');
+  test('removes a track and disables save when playlist is empty', async ({
+    page,
+  }) => {
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
+    await app.playlist.fillTitle('Solo Track');
 
-    const playlist = page.getByTestId('playlist-section');
-    await playlist.getByTestId('track-remove-track-1').click();
+    await app.playlist.clickRemoveTrack('track-1');
 
-    await expect(playlist.getByTestId('track-remove-track-1')).not.toBeVisible();
-    await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
+    await expect(app.playlist.trackRemoveButton('track-1')).not.toBeVisible();
+    await expect(app.playlist.saveButton()).toBeDisabled();
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 });

--- a/e2e/ui/mobile/remove-track.spec.ts
+++ b/e2e/ui/mobile/remove-track.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures/test';
-import { expectNoHorizontalOverflow, searchAndAddFirstTrack } from '../../fixtures/helpers';
+import { hasHorizontalOverflow, searchAndAddFirstTrack } from '../../fixtures/helpers';
 
 test.describe('Mobile remove track', () => {
   test('removes a track and disables save when playlist is empty', async ({ page }) => {
@@ -11,6 +11,6 @@ test.describe('Mobile remove track', () => {
 
     await expect(playlist.getByTestId('track-remove-track-1')).not.toBeVisible();
     await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
-    await expectNoHorizontalOverflow(page);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 });

--- a/e2e/ui/mobile/save-playlist.spec.ts
+++ b/e2e/ui/mobile/save-playlist.spec.ts
@@ -1,16 +1,32 @@
 import { test, expect } from '../../fixtures/test';
-import {
-  hasHorizontalOverflow,
-  searchAndAddFirstTrack,
-  savePlaylist,
-} from '../../fixtures/helpers';
+import { mockPlaylist, mockUser } from '../../fixtures/spotify-mocks';
+import { hasHorizontalOverflow } from '../../fixtures/helpers';
+import { AppPage } from '../../pages';
 
 test.describe('Mobile save playlist', () => {
   test('saves playlist and shows success message', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await savePlaylist(page, 'Mobile Mix');
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
 
-    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
+    const meRequest = page.waitForRequest('**/api.spotify.com/v1/me');
+    const createPlaylistRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes(`/v1/users/${mockUser.id}/playlists`) &&
+        !request.url().includes('/tracks'),
+    );
+    const addTracksRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes(`/playlists/${mockPlaylist.id}/tracks`),
+    );
+
+    await app.playlist.savePlaylist('Mobile Mix');
+    await meRequest;
+    await createPlaylistRequest;
+    await addTracksRequest;
+
+    await expect(app.playlist.message()).toHaveText('Playlist created');
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 });

--- a/e2e/ui/mobile/save-playlist.spec.ts
+++ b/e2e/ui/mobile/save-playlist.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../../fixtures/test';
 import {
-  expectNoHorizontalOverflow,
+  hasHorizontalOverflow,
   searchAndAddFirstTrack,
   savePlaylist,
 } from '../../fixtures/helpers';
@@ -11,6 +11,6 @@ test.describe('Mobile save playlist', () => {
     await savePlaylist(page, 'Mobile Mix');
 
     await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
-    await expectNoHorizontalOverflow(page);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 });

--- a/e2e/ui/mobile/search-and-add.spec.ts
+++ b/e2e/ui/mobile/search-and-add.spec.ts
@@ -1,14 +1,21 @@
 import { test, expect } from '../../fixtures/test';
 import { mockTracks } from '../../fixtures/spotify-mocks';
-import { hasHorizontalOverflow, searchAndAddFirstTrack } from '../../fixtures/helpers';
+import { hasHorizontalOverflow } from '../../fixtures/helpers';
+import { AppPage } from '../../pages';
 
 test.describe('Mobile search and add', () => {
   test('searches for tracks and adds one to the playlist', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
+    const app = new AppPage(page);
+    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
 
-    const playlist = page.getByTestId('playlist-section');
-    await expect(playlist.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
-    await expect(playlist.getByTestId('track-remove-track-1')).toBeVisible();
+    await app.searchAndAddTrack();
+    const request = await searchRequest;
+
+    expect(new URL(request.url()).searchParams.get('q')).toBe('test song');
+    await expect(app.playlist.trackNameInPlaylist('track-1')).toHaveText(
+      mockTracks[0].name,
+    );
+    await expect(app.playlist.trackRemoveButton('track-1')).toBeVisible();
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 });

--- a/e2e/ui/mobile/search-and-add.spec.ts
+++ b/e2e/ui/mobile/search-and-add.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../../fixtures/test';
 import { mockTracks } from '../../fixtures/spotify-mocks';
-import { expectNoHorizontalOverflow, searchAndAddFirstTrack } from '../../fixtures/helpers';
+import { hasHorizontalOverflow, searchAndAddFirstTrack } from '../../fixtures/helpers';
 
 test.describe('Mobile search and add', () => {
   test('searches for tracks and adds one to the playlist', async ({ page }) => {
@@ -9,6 +9,6 @@ test.describe('Mobile search and add', () => {
     const playlist = page.getByTestId('playlist-section');
     await expect(playlist.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
     await expect(playlist.getByTestId('track-remove-track-1')).toBeVisible();
-    await expectNoHorizontalOverflow(page);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 });

--- a/e2e/ui/mobile/validation.spec.ts
+++ b/e2e/ui/mobile/validation.spec.ts
@@ -1,16 +1,25 @@
 import { test, expect } from '../../fixtures/test';
 import { hasHorizontalOverflow } from '../../fixtures/helpers';
+import { PlaylistPage, SearchPage } from '../../pages';
 
 test.describe('Mobile validation', () => {
-  test('shows inline error when searching with an empty query', async ({ page }) => {
-    await page.getByTestId('search-button').click();
-    await expect(page.getByTestId('search-error')).toHaveText('Please enter a song title');
+  test('shows inline error when searching with an empty query', async ({
+    page,
+  }) => {
+    const search = new SearchPage(page);
+
+    await search.clickSearch();
+
+    await expect(search.searchError()).toHaveText('Please enter a song title');
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 
   test('disables save button when playlist has no tracks', async ({ page }) => {
-    await page.getByTestId('playlist-title-input').fill('Empty Playlist');
-    await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
+    const playlist = new PlaylistPage(page);
+
+    await playlist.fillTitle('Empty Playlist');
+
+    await expect(playlist.saveButton()).toBeDisabled();
     expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 });

--- a/e2e/ui/mobile/validation.spec.ts
+++ b/e2e/ui/mobile/validation.spec.ts
@@ -1,16 +1,16 @@
 import { test, expect } from '../../fixtures/test';
-import { expectNoHorizontalOverflow } from '../../fixtures/helpers';
+import { hasHorizontalOverflow } from '../../fixtures/helpers';
 
 test.describe('Mobile validation', () => {
   test('shows inline error when searching with an empty query', async ({ page }) => {
     await page.getByTestId('search-button').click();
     await expect(page.getByTestId('search-error')).toHaveText('Please enter a song title');
-    await expectNoHorizontalOverflow(page);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 
   test('disables save button when playlist has no tracks', async ({ page }) => {
     await page.getByTestId('playlist-title-input').fill('Empty Playlist');
     await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
-    await expectNoHorizontalOverflow(page);
+    expect(await hasHorizontalOverflow(page)).toBe(false);
   });
 });

--- a/e2e/ui/playlist-message.spec.ts
+++ b/e2e/ui/playlist-message.spec.ts
@@ -1,30 +1,52 @@
 import { test, expect } from '../fixtures/test';
-import { mockTracks } from '../fixtures/spotify-mocks';
-import { searchAndAddFirstTrack, savePlaylist, searchTracks } from '../fixtures/helpers';
+import { mockTracks, mockPlaylist, mockUser } from '../fixtures/spotify-mocks';
+import { AppPage } from '../pages';
 
 test.describe('Playlist message', () => {
   test('clears success message when playlist title changes', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await savePlaylist(page, 'Weekend Vibes');
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
 
-    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
+    const meRequest = page.waitForRequest('**/api.spotify.com/v1/me');
+    const createPlaylistRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes(`/v1/users/${mockUser.id}/playlists`) &&
+        !request.url().includes('/tracks'),
+    );
+    const addTracksRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes(`/playlists/${mockPlaylist.id}/tracks`),
+    );
 
-    await page.getByTestId('playlist-title-input').fill('New Playlist');
-    await expect(page.getByTestId('playlist-message')).toHaveText('');
+    await app.playlist.savePlaylist('Weekend Vibes');
+    await meRequest;
+    await createPlaylistRequest;
+    await addTracksRequest;
+
+    await expect(app.playlist.message()).toHaveText('Playlist created');
+
+    await app.playlist.fillTitle('New Playlist');
+    await expect(app.playlist.message()).toHaveText('');
   });
-});
 
-  test('clears duplicate track message when a different track is added', async ({ page }) => {
-    await searchTracks(page);
-    await page.getByTestId('track-add-track-1').click();
-    await page.getByTestId('track-add-track-1').click();
+  test('clears duplicate track message when a different track is added', async ({
+    page,
+  }) => {
+    const app = new AppPage(page);
 
-    await expect(page.getByTestId('playlist-message')).toHaveText('This song is in the playlist.');
+    await app.search.fillAndSearch('test song');
+    await app.search.clickAddTrack('track-1');
+    await app.search.clickAddTrack('track-1');
 
-    await page.getByTestId('track-add-track-2').click();
+    await expect(app.playlist.message()).toHaveText('This song is in the playlist.');
 
-    await expect(page.getByTestId('playlist-message')).toHaveText('');
-    await expect(page.getByTestId('playlist-section').getByTestId('track-name-track-2')).toHaveText(
-      mockTracks[1].name
+    await app.search.clickAddTrack('track-2');
+
+    await expect(app.playlist.message()).toHaveText('');
+    await expect(app.playlist.trackNameInPlaylist('track-2')).toHaveText(
+      mockTracks[1].name,
     );
   });
+});

--- a/e2e/ui/remove-track.spec.ts
+++ b/e2e/ui/remove-track.spec.ts
@@ -1,29 +1,31 @@
 import { test, expect } from '../fixtures/test';
 import { mockTracks } from '../fixtures/spotify-mocks';
-import { searchAndAddFirstTrack } from '../fixtures/helpers';
+import { AppPage } from '../pages';
 
 test.describe('Remove track from playlist', () => {
   test('removes a track from the playlist panel', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
 
-    const playlist = page.getByTestId('playlist-section');
-    await expect(playlist.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+    await expect(app.playlist.trackNameInPlaylist('track-1')).toHaveText(
+      mockTracks[0].name,
+    );
 
-    await playlist.getByTestId('track-remove-track-1').click();
+    await app.playlist.clickRemoveTrack('track-1');
 
-    await expect(playlist.getByTestId('track-remove-track-1')).not.toBeVisible();
-    await expect(page.getByTestId('track-add-track-1')).toBeVisible();
-    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+    await expect(app.playlist.trackRemoveButton('track-1')).not.toBeVisible();
+    await expect(app.search.trackAddButton('track-1')).toBeVisible();
+    await expect(app.search.trackName('track-1')).toHaveText(mockTracks[0].name);
   });
 
   test('disables save button after removing the last track', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await page.getByTestId('playlist-title-input').fill('Solo Track');
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
+    await app.playlist.fillTitle('Solo Track');
 
-    const playlist = page.getByTestId('playlist-section');
-    await playlist.getByTestId('track-remove-track-1').click();
+    await app.playlist.clickRemoveTrack('track-1');
 
-    await expect(playlist.getByTestId('track-remove-track-1')).not.toBeVisible();
-    await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
+    await expect(app.playlist.trackRemoveButton('track-1')).not.toBeVisible();
+    await expect(app.playlist.saveButton()).toBeDisabled();
   });
 });

--- a/e2e/ui/save-playlist.spec.ts
+++ b/e2e/ui/save-playlist.spec.ts
@@ -1,37 +1,72 @@
 import { test, expect } from '../fixtures/test';
-import { mockTracks } from '../fixtures/spotify-mocks';
+import { mockTracks, mockPlaylist, mockUser } from '../fixtures/spotify-mocks';
 import { mockSpotifyApi } from '../fixtures/mock-spotify-api';
-import { searchAndAddFirstTrack, savePlaylist } from '../fixtures/helpers';
+import { AppPage } from '../pages';
+import { parseCreatePlaylistRequest } from '../schemas/validate';
 
 test.describe('Save playlist', () => {
   test('saves playlist and shows success message', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await savePlaylist(page, 'Weekend Vibes');
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
 
-    await expect(page.getByTestId('playlist-message')).toHaveText('Playlist created');
+    const meRequest = page.waitForRequest('**/api.spotify.com/v1/me');
+    const createPlaylistRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes(`/v1/users/${mockUser.id}/playlists`) &&
+        !request.url().includes('/tracks'),
+    );
+    const addTracksRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes(`/playlists/${mockPlaylist.id}/tracks`),
+    );
+
+    await app.playlist.savePlaylist('Weekend Vibes');
+
+    await meRequest;
+    const createPlaylist = await createPlaylistRequest;
+    await addTracksRequest;
+
+    expect(parseCreatePlaylistRequest(createPlaylist.postDataJSON())).toEqual({
+      name: 'Weekend Vibes',
+    });
+    await expect(app.playlist.message()).toHaveText('Playlist created');
   });
 
   test('clears playlist after successful save', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await savePlaylist(page, 'Weekend Vibes');
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
 
-    await expect(page.getByTestId('playlist-title-input')).toHaveValue('');
-    await expect(
-      page.getByTestId('playlist-section').getByTestId('track-remove-track-1')
-    ).not.toBeVisible();
-    await expect(page.getByTestId('track-add-track-1')).toBeVisible();
-    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
+    const meRequest = page.waitForRequest('**/api.spotify.com/v1/me');
+    await app.playlist.savePlaylist('Weekend Vibes');
+    await meRequest;
+
+    await expect(app.playlist.titleInput()).toHaveValue('');
+    await expect(app.playlist.trackRemoveButton('track-1')).not.toBeVisible();
+    await expect(app.search.trackAddButton('track-1')).toBeVisible();
+    await expect(app.search.trackName('track-1')).toHaveText(mockTracks[0].name);
   });
 
   test('shows error message when save fails', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await page.getByTestId('playlist-title-input').fill('Failed Playlist');
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
+    await app.playlist.fillTitle('Failed Playlist');
+    // [QA_AUDIT_REQUIRED]: Mocking create playlist 500. Cannot force Spotify server errors in CI.
     await mockSpotifyApi(page, { createPlaylistStatus: 500 });
 
-    await page.getByTestId('save-playlist-button').click();
+    const createPlaylistRequest = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes('/playlists') &&
+        !request.url().includes('/tracks'),
+    );
 
-    await expect(page.getByTestId('playlist-message')).toHaveText(
-      'Unable to save playlist. Please try again.'
+    await app.playlist.clickSave();
+    await createPlaylistRequest;
+
+    await expect(app.playlist.message()).toHaveText(
+      'Unable to save playlist. Please try again.',
     );
   });
 });

--- a/e2e/ui/search-and-add.spec.ts
+++ b/e2e/ui/search-and-add.spec.ts
@@ -1,48 +1,65 @@
 import { test, expect } from '../fixtures/test';
 import { mockTracks } from '../fixtures/spotify-mocks';
 import { mockEmptySearchResults } from '../fixtures/mock-spotify-api';
-import { searchTracks } from '../fixtures/helpers';
+import { AppPage, SearchPage } from '../pages';
 
 test.describe('Search and add to playlist', () => {
   test('searches for tracks and displays results', async ({ page }) => {
-    await searchTracks(page);
+    const search = new SearchPage(page);
+    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
 
-    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
-    await expect(page.getByTestId('track-artist-track-1')).toHaveText(
-      mockTracks[0].artists[0].name
+    await search.fillAndSearch('test song');
+    const request = await searchRequest;
+
+    expect(new URL(request.url()).searchParams.get('q')).toBe('test song');
+    await expect(search.trackName('track-1')).toHaveText(mockTracks[0].name);
+    await expect(search.trackArtist('track-1')).toHaveText(
+      mockTracks[0].artists[0].name,
     );
-    await expect(page.getByRole('heading', { name: 'Results' })).toBeVisible();
+    await expect(search.resultsHeading()).toBeVisible();
   });
 
   test('adds a track from results to the playlist panel', async ({ page }) => {
-    await searchTracks(page);
+    const app = new AppPage(page);
+    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
 
-    await page.getByTestId('track-add-track-1').click();
+    await app.search.fillAndSearch('test song');
+    await searchRequest;
+    await app.search.clickAddTrack('track-1');
 
-    const playlist = page.getByTestId('playlist-section');
-    await expect(playlist.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
-    await expect(playlist.getByTestId('track-remove-track-1')).toBeVisible();
-    await expect(page.getByTestId('track-add-track-1')).toBeVisible();
+    await expect(app.playlist.trackNameInPlaylist('track-1')).toHaveText(
+      mockTracks[0].name,
+    );
+    await expect(app.playlist.trackRemoveButton('track-1')).toBeVisible();
+    await expect(app.search.trackAddButton('track-1')).toBeVisible();
   });
 
   test('adds multiple tracks to the playlist panel', async ({ page }) => {
-    await searchTracks(page);
-    await page.getByTestId('track-add-track-1').click();
-    await page.getByTestId('track-add-track-2').click();
+    const app = new AppPage(page);
 
-    const playlist = page.getByTestId('playlist-section');
-    await expect(playlist.getByTestId('track-remove-track-1')).toBeVisible();
-    await expect(playlist.getByTestId('track-remove-track-2')).toBeVisible();
-    await expect(playlist.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
-    await expect(playlist.getByTestId('track-name-track-2')).toHaveText(mockTracks[1].name);
+    await app.search.fillAndSearch('test song');
+    await app.search.clickAddTrack('track-1');
+    await app.search.clickAddTrack('track-2');
+
+    await expect(app.playlist.trackRemoveButton('track-1')).toBeVisible();
+    await expect(app.playlist.trackRemoveButton('track-2')).toBeVisible();
+    await expect(app.playlist.trackNameInPlaylist('track-1')).toHaveText(
+      mockTracks[0].name,
+    );
+    await expect(app.playlist.trackNameInPlaylist('track-2')).toHaveText(
+      mockTracks[1].name,
+    );
   });
 
   test('shows empty state when search returns no tracks', async ({ page }) => {
+    const search = new SearchPage(page);
     await mockEmptySearchResults(page);
+    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
 
-    await page.getByTestId('search-by-input').fill('missing song');
-    await page.getByTestId('search-button').click();
+    await search.fillAndSearch('missing song');
+    const request = await searchRequest;
 
-    await expect(page.getByTestId('search-empty-message')).toHaveText('No results found');
+    expect(new URL(request.url()).searchParams.get('q')).toBe('missing song');
+    await expect(search.searchEmptyMessage()).toHaveText('No results found');
   });
 });

--- a/e2e/ui/search-enter.spec.ts
+++ b/e2e/ui/search-enter.spec.ts
@@ -1,12 +1,19 @@
 import { test, expect } from '../fixtures/test';
 import { mockTracks } from '../fixtures/spotify-mocks';
+import { SearchPage } from '../pages';
 
 test.describe('Search on Enter', () => {
-  test('searches for tracks when Enter is pressed in the search input', async ({ page }) => {
-    await page.getByTestId('search-by-input').fill('test song');
-    await page.getByTestId('search-by-input').press('Enter');
+  test('searches for tracks when Enter is pressed in the search input', async ({
+    page,
+  }) => {
+    const search = new SearchPage(page);
+    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
 
-    await expect(page.getByTestId('track-name-track-1')).toHaveText(mockTracks[0].name);
-    await expect(page.getByRole('heading', { name: 'Results' })).toBeVisible();
+    await search.submitSearchWithEnter('test song');
+    const request = await searchRequest;
+
+    expect(new URL(request.url()).searchParams.get('q')).toBe('test song');
+    await expect(search.trackName('track-1')).toHaveText(mockTracks[0].name);
+    await expect(search.resultsHeading()).toBeVisible();
   });
 });

--- a/e2e/ui/search-failure.spec.ts
+++ b/e2e/ui/search-failure.spec.ts
@@ -1,16 +1,21 @@
 import { test, expect } from '../fixtures/test';
 import { mockSpotifyApi } from '../fixtures/mock-spotify-api';
+import { SearchPage } from '../pages';
 
 test.describe('Search failure', () => {
   test('shows an error message when Spotify search fails', async ({ page }) => {
+    // [QA_AUDIT_REQUIRED]: Mocking search 500. Cannot force Spotify search errors in CI.
     await mockSpotifyApi(page, { searchStatus: 500 });
+    const search = new SearchPage(page);
+    const searchRequest = page.waitForRequest('**/api.spotify.com/v1/search*');
 
-    await page.getByTestId('search-by-input').fill('test');
-    await page.getByTestId('search-button').click();
+    await search.fillAndSearch('test');
+    const request = await searchRequest;
 
-    await expect(page.getByTestId('search-api-error')).toHaveText(
-      'Unable to search right now. Please try again.'
+    expect(new URL(request.url()).searchParams.get('q')).toBe('test');
+    await expect(search.searchApiError()).toHaveText(
+      'Unable to search right now. Please try again.',
     );
-    await expect(page.getByTestId('track-name-track-1')).not.toBeVisible();
+    await expect(search.trackName('track-1')).not.toBeVisible();
   });
 });

--- a/e2e/ui/validation.spec.ts
+++ b/e2e/ui/validation.spec.ts
@@ -1,38 +1,50 @@
 import { test, expect } from '../fixtures/test';
-import { searchAndAddFirstTrack } from '../fixtures/helpers';
+import { AppPage, PlaylistPage, SearchPage } from '../pages';
 
 test.describe('Form validation', () => {
   test('shows inline error when searching with an empty query', async ({ page }) => {
-    await page.getByTestId('search-button').click();
-    await expect(page.getByTestId('search-error')).toHaveText('Please enter a song title');
+    const search = new SearchPage(page);
+
+    await search.clickSearch();
+
+    await expect(search.searchError()).toHaveText('Please enter a song title');
   });
 
   test('clears search error after typing in the input', async ({ page }) => {
-    await page.getByTestId('search-button').click();
-    await expect(page.getByTestId('search-error')).toBeVisible();
+    const search = new SearchPage(page);
 
-    await page.getByTestId('search-by-input').fill('t');
-    await expect(page.getByTestId('search-error')).not.toBeVisible();
+    await search.clickSearch();
+    await expect(search.searchError()).toBeVisible();
+
+    await search.fillSearch('t');
+    await expect(search.searchError()).not.toBeVisible();
   });
 
-  test('shows inline error when saving without a playlist title', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await page.getByTestId('save-playlist-button').click();
-    await expect(page.getByTestId('playlist-validation-error')).toHaveText('Add a playlist title');
+  test('shows inline error when saving without a playlist title', async ({
+    page,
+  }) => {
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
+
+    await app.playlist.clickSave();
+
+    await expect(app.playlist.validationError()).toHaveText('Add a playlist title');
   });
 
   test('disables save button when playlist has no tracks', async ({ page }) => {
-    await page.getByTestId('playlist-title-input').fill('Empty Playlist');
-    await expect(page.getByTestId('save-playlist-button')).toBeDisabled();
+    const playlist = new PlaylistPage(page);
+
+    await playlist.fillTitle('Empty Playlist');
+
+    await expect(playlist.saveButton()).toBeDisabled();
   });
 
   test('shows duplicate track message in playlist panel', async ({ page }) => {
-    await searchAndAddFirstTrack(page);
-    await page.getByTestId('track-add-track-1').click();
+    const app = new AppPage(page);
+    await app.searchAndAddTrack();
+    await app.search.clickAddTrack('track-1');
 
-    await expect(page.getByTestId('playlist-message')).toHaveText('This song is in the playlist.');
-    await expect(
-      page.getByTestId('playlist-section').getByTestId('track-remove-track-1')
-    ).toHaveCount(1);
+    await expect(app.playlist.message()).toHaveText('This song is in the playlist.');
+    await expect(app.playlist.trackRemoveButton('track-1')).toHaveCount(1);
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,4 +77,10 @@ export default tseslint.config(
       'testing-library/prefer-screen-queries': 'off',
     },
   },
+  {
+    files: ['scripts/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.2",
         "vite": "^5.4.11",
-        "vitest": "^2.1.8"
+        "vitest": "^2.1.8",
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:ui:mobile": "playwright test --project ui-mobile",
     "test:e2e:ui": "playwright test --ui",
     "test:coverage": "mkdir -p test-results && vitest run --coverage --reporter=json --outputFile=test-results/jest.json",
-    "lint": "eslint src e2e --max-warnings 0",
+    "lint": "eslint src e2e --max-warnings 0 && node scripts/qa-test-guards.mjs",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit && tsc -p tsconfig.e2e.json --noEmit",
     "test:all": "npm run test:coverage && npm run test:e2e:ci"
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.2",
     "vite": "^5.4.11",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "zod": "^4.4.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ const SERVE_BUILD = process.env.CI_SERVE_BUILD === 'true';
 const HOMEPAGE_PATH = '/cc_jammming_music';
 const baseURL =
   process.env.PLAYWRIGHT_BASE_URL ||
-  `http://localhost:${PORT}${HOMEPAGE_PATH}`;
+  `http://127.0.0.1:${PORT}${HOMEPAGE_PATH}/`;
 
 const devWebServer = {
   command: 'npm start',
@@ -16,7 +16,7 @@ const devWebServer = {
     PORT,
     VITE_SPOTIFY_CLIENT_ID:
       process.env.VITE_SPOTIFY_CLIENT_ID || 'test-client-id',
-    VITE_REDIRECT_URI: process.env.VITE_REDIRECT_URI || `${baseURL}/`,
+    VITE_REDIRECT_URI: process.env.VITE_REDIRECT_URI || baseURL,
   },
 };
 

--- a/scripts/qa-test-guards.mjs
+++ b/scripts/qa-test-guards.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const root = process.cwd();
+const failures = [];
+
+function walk(dir) {
+  const entries = readdirSync(dir);
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      files.push(...walk(fullPath));
+      continue;
+    }
+    if (fullPath.endsWith('.ts') || fullPath.endsWith('.tsx')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function rel(filePath) {
+  return relative(root, filePath);
+}
+
+for (const file of walk(join(root, 'e2e'))) {
+  const text = readFileSync(file, 'utf8');
+  if (text.includes('waitForTimeout')) {
+    failures.push(`${rel(file)}: waitForTimeout is forbidden in e2e`);
+  }
+}
+
+for (const file of walk(join(root, 'e2e/pages'))) {
+  const text = readFileSync(file, 'utf8');
+  if (/\bexpect\s*\(/.test(text)) {
+    failures.push(`${rel(file)}: expect() is forbidden in page objects`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('QA test guards failed:\n');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('QA test guards passed.');

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,9 @@ import styles from './Header.module.css';
 const Header = () => {
   return (
     <header className={styles.header}>
-      <h1 className={styles.title}>Jamming</h1>
+      <h1 className={styles.title} data-testid="app-title">
+        Jamming
+      </h1>
     </header>
   );
 };

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -39,7 +39,11 @@ function SearchBar({
       onSubmit={handleSubmit}
       data-testid="search-form"
     >
-      <label htmlFor="search-by-input" className={styles.searchLabel}>
+      <label
+        htmlFor="search-by-input"
+        className={styles.searchLabel}
+        data-testid="search-label"
+      >
         Search by song title
       </label>
       <input

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -19,7 +19,9 @@ function SearchResults({
 
   return (
     <div className={styles.searchResults}>
-      <h2 className={styles.panelTitle}>Results</h2>
+      <h2 className={styles.panelTitle} data-testid="results-heading">
+        Results
+      </h2>
       <div className={styles.resultsBody}>
         {showEmptyState ? (
           <p className={styles.emptyMessage} data-testid="search-empty-message">

--- a/src/util/Spotify.test.ts
+++ b/src/util/Spotify.test.ts
@@ -1,6 +1,7 @@
 import { webcrypto } from 'crypto';
 import { TextEncoder } from 'util';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { z } from 'zod';
 import type SpotifyType from './Spotify';
 import { PKCE_CODE_VERIFIER_STORAGE_KEY, SPOTIFY_TOKEN_URL } from './pkce';
 
@@ -11,12 +12,21 @@ const MOCK_CODE_VERIFIER = 'test-pkce-verifier-abcdefghijklmnopqrstuvwxyz123456'
 
 const mockFetch = vi.fn() as MockedFunction<typeof fetch>;
 
-const mockTokenResponse = {
+/** Keep unit fixtures aligned with E2E Spotify token contract. */
+const spotifyTokenResponseSchema = z.object({
+  access_token: z.string(),
+  token_type: z.string(),
+  scope: z.string(),
+  expires_in: z.number(),
+  refresh_token: z.string().optional(),
+});
+
+const mockTokenResponse = spotifyTokenResponseSchema.parse({
   access_token: MOCK_ACCESS_TOKEN,
   token_type: 'Bearer',
   scope: 'playlist-modify-public',
   expires_in: 3600,
-};
+});
 
 function mockSessionStorage() {
   const store = new Map<string, string>();


### PR DESCRIPTION
# Summary

<!-- What changed and why (1–3 bullets). -->

-

## Test plan

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` (or relevant unit tests)
- [ ] `npm run test:e2e:ci` / `npm run test:all` if behavior or tooling could affect CI
- [ ] Manual check on [http://127.0.0.1:3000/cc_jammming_music/](http://127.0.0.1:3000/cc_jammming_music/) when UI or auth changed
- [ ] Mobile smoke (`npm run test:ui:mobile`) when layout/CSS changed

## Notes

<!-- Screenshots, follow-ups, Dependabot / breaking-change callouts. -->
